### PR TITLE
refactor: plugin properties

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -1,7 +1,25 @@
-snyk.api.url=https://snyk.io/api/v1/
+# =======
+# General
+# =======
+
+# The base URL for all API endpoints (https://snyk.docs.apiary.io/#introduction/api-url).
+# Default value: https://snyk.io/api/v1/
+#snyk.api.url=https://snyk.io/api/v1/
+
+# The API token from Snyk account.
 snyk.api.token=
+
+# This ID uniquely identifies your organization (see Snyk account).
 snyk.api.organization=
-#
+
+
+# =====================
 # Scanner configuration
+# =====================
+
+# Global threshold for vulnerability issues. Valid values include "low", "medium", "high".
+# Default value: "low"
 snyk.artifactory.scanner.vulnerability.threshold=low
+# Global threshold for license issues. Valid values include "low", "medium", "high".
+# Default value: "low"
 snyk.artifactory.scanner.license.threshold=low

--- a/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
@@ -10,10 +10,12 @@ import io.snyk.plugins.artifactory.exception.SnykRuntimeException;
 import io.snyk.plugins.artifactory.scanner.ScannerModule;
 import io.snyk.sdk.Snyk;
 import io.snyk.sdk.api.v1.SnykClient;
+import io.snyk.sdk.model.NotificationSettings;
 import org.artifactory.repo.RepoPath;
 import org.artifactory.repo.Repositories;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import retrofit2.Response;
 
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_TOKEN;
@@ -28,12 +30,12 @@ public class SnykPlugin {
 
   public SnykPlugin(@Nonnull Repositories repositories, File pluginsDirectory) {
     try {
-      //load and validate plugin properties
+      LOG.info("Loading and validating plugin properties...");
       Properties properties = PropertyLoader.loadProperties(pluginsDirectory);
       configurationModule = new ConfigurationModule(properties);
       validateConfiguration();
 
-      //create api client and modules
+      LOG.info("Creating api client and modules...");
       final SnykClient snykClient = createSnykClient(configurationModule);
       scannerModule = new ScannerModule(configurationModule, repositories, snykClient);
     } catch (IOException ex) {
@@ -52,7 +54,6 @@ public class SnykPlugin {
   }
 
   private void validateConfiguration() {
-    LOG.info("Validate plugin configuration");
     try {
       configurationModule.validate();
     } catch (Exception ex) {
@@ -69,20 +70,29 @@ public class SnykPlugin {
   }
 
   @Nonnull
-  private SnykClient createSnykClient(ConfigurationModule configurationModule) {
-    String baseUrl = configurationModule.getPropertyOrDefault(API_URL);
-    if (!baseUrl.endsWith("/")) {
-      if (LOG.isWarnEnabled()) {
-        LOG.warn("'{}' must end in /, your value is '{}'", API_URL.propertyKey(), baseUrl);
-      }
-      baseUrl = baseUrl + "/";
-    }
+  private SnykClient createSnykClient(@Nonnull ConfigurationModule configurationModule) throws IOException {
+    final SnykClient snykClient;
     final String token = configurationModule.getPropertyOrDefault(API_TOKEN);
+    String baseUrl = configurationModule.getPropertyOrDefault(API_URL);
 
     if (baseUrl.isEmpty()) {
-      return Snyk.newBuilder(new Snyk.Config(token)).buildSync();
+      snykClient = Snyk.newBuilder(new Snyk.Config(token)).buildSync();
     } else {
-      return Snyk.newBuilder(new Snyk.Config(baseUrl, token)).buildSync();
+      if (!baseUrl.endsWith("/")) {
+        if (LOG.isWarnEnabled()) {
+          LOG.warn("'{}' must end in /, your value is '{}'", API_URL.propertyKey(), baseUrl);
+        }
+        baseUrl = baseUrl + "/";
+      }
+      snykClient = Snyk.newBuilder(new Snyk.Config(baseUrl, token)).buildSync();
     }
+
+    // get notification settings to check whether api token is valid
+    Response<NotificationSettings> response = snykClient.getNotificationSettings().execute();
+    if (response.code() == 401) {
+      throw new SnykRuntimeException("Invalid 'snyk.api.token' provided");
+    }
+
+    return snykClient;
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
@@ -79,6 +79,10 @@ public class SnykPlugin {
     }
     final String token = configurationModule.getPropertyOrDefault(API_TOKEN);
 
-    return Snyk.newBuilder(new Snyk.Config(baseUrl, token)).buildSync();
+    if (baseUrl.isEmpty()) {
+      return Snyk.newBuilder(new Snyk.Config(token)).buildSync();
+    } else {
+      return Snyk.newBuilder(new Snyk.Config(baseUrl, token)).buildSync();
+    }
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -2,7 +2,7 @@ package io.snyk.plugins.artifactory.configuration;
 
 public enum PluginConfiguration implements Configuration {
   // general settings
-  API_URL("snyk.api.url", "https://snyk.io/api/v1/"),
+  API_URL("snyk.api.url", ""),
   API_TOKEN("snyk.api.token", ""),
   API_ORGANIZATION("snyk.api.organization", ""),
 

--- a/core/src/main/java/io/snyk/plugins/artifactory/exception/SnykRuntimeException.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/exception/SnykRuntimeException.java
@@ -4,6 +4,10 @@ public class SnykRuntimeException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 
+  public SnykRuntimeException(String message) {
+    super(message);
+  }
+
   public SnykRuntimeException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/core/src/test/java/io/snyk/plugins/artifactory/configuration/PluginConfigurationTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/configuration/PluginConfigurationTest.java
@@ -18,12 +18,12 @@ class PluginConfigurationTest {
   @Test
   void checkDefaultValues() {
     assertAll("should be not empty",
-              () -> assertEquals("https://snyk.io/api/v1/", API_URL.defaultValue(), getAssertionMessage(API_URL, "default value must be 'https://snyk.io/api/v1/'")),
               () -> assertEquals("low", SCANNER_VULNERABILITY_THRESHOLD.defaultValue(), getAssertionMessage(SCANNER_VULNERABILITY_THRESHOLD, "default value must be 'low'")),
               () -> assertEquals("low", SCANNER_LICENSE_THRESHOLD.defaultValue(), getAssertionMessage(SCANNER_LICENSE_THRESHOLD, "default value must be 'low'"))
     );
 
     assertAll("should be empty",
+              () -> assertEquals("", API_URL.defaultValue(), getAssertionMessage(API_URL, "default value must be empty")),
               () -> assertEquals("", API_TOKEN.defaultValue(), getAssertionMessage(API_TOKEN, "default value must be empty")),
               () -> assertEquals("", API_ORGANIZATION.defaultValue(), getAssertionMessage(API_ORGANIZATION, "default value must be empty"))
     );

--- a/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
@@ -2,6 +2,7 @@ package io.snyk.sdk.api.v1;
 
 import javax.annotation.Nullable;
 
+import io.snyk.sdk.model.NotificationSettings;
 import io.snyk.sdk.model.TestResult;
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -9,6 +10,12 @@ import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 public interface SnykClient {
+
+  /**
+   * Get the user notification settings that will determine which emails are sent.
+   */
+  @GET("user/me/notification-settings")
+  Call<NotificationSettings> getNotificationSettings();
 
   /**
    * Test Maven packages for issues according to their coordinates: group ID, artifact ID and version:

--- a/snyk-sdk/src/main/java/io/snyk/sdk/model/NotificationSettings.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/model/NotificationSettings.java
@@ -1,0 +1,34 @@
+package io.snyk.sdk.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The user notification settings that will determine which emails are sent.
+ */
+public class NotificationSettings implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @JsonProperty("educational-information")
+  public EducationalInformation educationalInformation;
+  @JsonProperty("product-updates")
+  public ProductUpdates productUpdates;
+}
+
+class EducationalInformation implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @JsonProperty("enabled")
+  public boolean enabled;
+}
+
+class ProductUpdates implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @JsonProperty("enabled")
+  public boolean enabled;
+}


### PR DESCRIPTION
- set empty default value for `snyk.api.url`
- add documentation snippets for each property
- call `user/me/notification-settings` endpoint to check if api token is valid, if not -> we don't load plugin by artifactory boostrap. It's better if we fails as soon as possible and not on `beforeDownload` extension point.