### PR TITLE
feat: allow or block artifact downloads when Snyk API is unavailable

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -17,9 +17,13 @@ snyk.api.organization=
 # Scanner configuration
 # =====================
 
+# By default, if Snyk API becomes unavailable for any reason, all artifact downloads are blocked.
+# Setting this property to "false" allows download of artifacts.
+# Default value: "true"
+snyk.scanner.block-on-api-failure=true
 # Global threshold for vulnerability issues. Valid values include "low", "medium", "high".
 # Default value: "low"
-snyk.artifactory.scanner.vulnerability.threshold=low
+snyk.scanner.vulnerability.threshold=low
 # Global threshold for license issues. Valid values include "low", "medium", "high".
 # Default value: "low"
-snyk.artifactory.scanner.license.threshold=low
+snyk.scanner.license.threshold=low

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -7,6 +7,7 @@ public enum PluginConfiguration implements Configuration {
   API_ORGANIZATION("snyk.api.organization", ""),
 
   // scanner module
+  SCANNER_BLOCK_ON_API_FAILURE("snyk.scanner.block-on-api-failure", "true"),
   SCANNER_VULNERABILITY_THRESHOLD("snyk.scanner.vulnerability.threshold", "low"),
   SCANNER_LICENSE_THRESHOLD("snyk.scanner.license.threshold", "low");
 

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -63,7 +63,7 @@ public class ScannerModule {
       final String blockOnApiFailurePropertyKey = SCANNER_BLOCK_ON_API_FAILURE.propertyKey();
       final String blockOnApiFailure = configurationModule.getPropertyOrDefault(SCANNER_BLOCK_ON_API_FAILURE);
       if ("true".equals(blockOnApiFailure)) {
-        throw new CancelException(format("Artifact '%s' could not be scanned and '%s' is 'true'", repoPath, blockOnApiFailurePropertyKey), 500);
+        throw new CancelException(format("Artifact '%s' could not be scanned because Snyk API is not available", repoPath), 500);
       } else {
         LOG.warn("Property '{}' is false, so we allow to download the artifact '{}'", blockOnApiFailurePropertyKey, repoPath);
         return;

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -24,6 +24,7 @@ import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_U
 import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES;
 import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
 import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO;
+import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_BLOCK_ON_API_FAILURE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -59,8 +60,14 @@ public class ScannerModule {
     }
 
     if (testResult == null) {
-      LOG.error("Scanning was not successful");
-      return;
+      final String blockOnApiFailurePropertyKey = SCANNER_BLOCK_ON_API_FAILURE.propertyKey();
+      final String blockOnApiFailure = configurationModule.getPropertyOrDefault(SCANNER_BLOCK_ON_API_FAILURE);
+      if ("true".equals(blockOnApiFailure)) {
+        throw new CancelException(format("Artifact '%s' could not be scanned and '%s' is 'true'", repoPath, blockOnApiFailurePropertyKey), 500);
+      } else {
+        LOG.warn("Property '{}' is false, so we allow to download the artifact '{}'", blockOnApiFailurePropertyKey, repoPath);
+        return;
+      }
     }
 
     updateProperties(repoPath, fileLayoutInfo, testResult);

--- a/core/src/test/java/io/snyk/plugins/artifactory/configuration/PluginConfigurationTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/configuration/PluginConfigurationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_TOKEN;
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_URL;
+import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_BLOCK_ON_API_FAILURE;
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_LICENSE_THRESHOLD;
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_VULNERABILITY_THRESHOLD;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -18,6 +19,7 @@ class PluginConfigurationTest {
   @Test
   void checkDefaultValues() {
     assertAll("should be not empty",
+              () -> assertEquals("true", SCANNER_BLOCK_ON_API_FAILURE.defaultValue(), getAssertionMessage(SCANNER_BLOCK_ON_API_FAILURE, "default value must be 'true'")),
               () -> assertEquals("low", SCANNER_VULNERABILITY_THRESHOLD.defaultValue(), getAssertionMessage(SCANNER_VULNERABILITY_THRESHOLD, "default value must be 'low'")),
               () -> assertEquals("low", SCANNER_LICENSE_THRESHOLD.defaultValue(), getAssertionMessage(SCANNER_LICENSE_THRESHOLD, "default value must be 'low'"))
     );


### PR DESCRIPTION
The new property is for scanner module `snyk.scanner.block-on-api-failure` with default value `true`.