### PR TITLE
feat: add audit logging for 'forceDownload' properties

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.groovy
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.groovy
@@ -1,6 +1,7 @@
 package io.snyk.plugins.artifactory
 
 import groovy.transform.Field
+import org.artifactory.fs.ItemInfo
 import org.artifactory.repo.RepoPath
 import org.artifactory.request.Request
 
@@ -26,5 +27,11 @@ executions {
 download {
   beforeDownload { Request request, RepoPath repoPath ->
     snykPlugin.handleBeforeDownloadEvent(repoPath)
+  }
+}
+
+storage {
+  afterPropertyCreate { ItemInfo itemInfo, String propertyName, String[] propertyValues ->
+    snykPlugin.handleAfterPropertyCreateEvent(security.currentUser(), itemInfo, propertyName, propertyValues)
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/audit/AuditModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/audit/AuditModule.java
@@ -1,0 +1,45 @@
+package io.snyk.plugins.artifactory.audit;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.artifactory.fs.ItemInfo;
+import org.artifactory.security.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
+import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD_INFO;
+import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
+import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO;
+
+public class AuditModule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuditModule.class);
+
+  public AuditModule() {
+    //squid:S1186
+  }
+
+  public void logPropertyUpdate(@Nullable User user, @Nonnull ItemInfo itemInfo, String propertyName, String[] propertyValues) {
+    if (propertyName == null || !propertyIsRelevant(propertyName)) {
+      return;
+    }
+
+    String username = "";
+    if (user == null) {
+      LOG.warn("No authentication details are present for current user!");
+    } else {
+      username = user.getUsername() + "/" + user.getLastLoginClientIp();
+    }
+
+    LOG.info("Artifact: '{}'. User '{}' updated property '{}' with value '{}'.", itemInfo.getRepoPath(), username, propertyName, propertyValues);
+  }
+
+  private boolean propertyIsRelevant(@Nonnull String propertyName) {
+    return ISSUE_LICENSES_FORCE_DOWNLOAD.propertyKey().equals(propertyName) ||
+      ISSUE_LICENSES_FORCE_DOWNLOAD_INFO.propertyKey().equals(propertyName) ||
+      ISSUE_VULNERABILITIES_FORCE_DOWNLOAD.propertyKey().equals(propertyName) ||
+      ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO.propertyKey().equals(propertyName);
+  }
+}


### PR DESCRIPTION
This PR adds a new audit module used by `storage->afterPropertyCreate` extension point. This module logs updates for all `forceDownload` (vulns and licenses) properties.