### PR TITLE
fix: specify user agent for plugin

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
@@ -28,6 +28,8 @@ import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_
 public class SnykPlugin {
 
   private static final Logger LOG = LoggerFactory.getLogger(SnykPlugin.class);
+  //TODO(pavel): currently version is hard-coded, will be dynamically loaded later from property file
+  private static final String API_USER_AGENT = "snyk-artifactory-plugin/0.0.5";
 
   private final ConfigurationModule configurationModule;
   private final AuditModule auditModule;
@@ -97,17 +99,13 @@ public class SnykPlugin {
     final String token = configurationModule.getPropertyOrDefault(API_TOKEN);
     String baseUrl = configurationModule.getPropertyOrDefault(API_URL);
 
-    if (baseUrl.isEmpty()) {
-      snykClient = Snyk.newBuilder(new Snyk.Config(token)).buildSync();
-    } else {
-      if (!baseUrl.endsWith("/")) {
-        if (LOG.isWarnEnabled()) {
-          LOG.warn("'{}' must end in /, your value is '{}'", API_URL.propertyKey(), baseUrl);
-        }
-        baseUrl = baseUrl + "/";
+    if (!baseUrl.endsWith("/")) {
+      if (LOG.isWarnEnabled()) {
+        LOG.warn("'{}' must end in /, your value is '{}'", API_URL.propertyKey(), baseUrl);
       }
-      snykClient = Snyk.newBuilder(new Snyk.Config(baseUrl, token)).buildSync();
+      baseUrl = baseUrl + "/";
     }
+    snykClient = Snyk.newBuilder(new Snyk.Config(baseUrl, token, API_USER_AGENT)).buildSync();
 
     // get notification settings to check whether api token is valid
     Response<NotificationSettings> response = snykClient.getNotificationSettings().execute();

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -2,7 +2,7 @@ package io.snyk.plugins.artifactory.configuration;
 
 public enum PluginConfiguration implements Configuration {
   // general settings
-  API_URL("snyk.api.url", ""),
+  API_URL("snyk.api.url", "https://snyk.io/api/v1/"),
   API_TOKEN("snyk.api.token", ""),
   API_ORGANIZATION("snyk.api.organization", ""),
 

--- a/core/src/test/java/io/snyk/plugins/artifactory/configuration/PluginConfigurationTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/configuration/PluginConfigurationTest.java
@@ -19,13 +19,13 @@ class PluginConfigurationTest {
   @Test
   void checkDefaultValues() {
     assertAll("should be not empty",
+              () -> assertEquals("https://snyk.io/api/v1/", API_URL.defaultValue(), getAssertionMessage(API_URL, "default value must be 'https://snyk.io/api/v1/'")),
               () -> assertEquals("true", SCANNER_BLOCK_ON_API_FAILURE.defaultValue(), getAssertionMessage(SCANNER_BLOCK_ON_API_FAILURE, "default value must be 'true'")),
               () -> assertEquals("low", SCANNER_VULNERABILITY_THRESHOLD.defaultValue(), getAssertionMessage(SCANNER_VULNERABILITY_THRESHOLD, "default value must be 'low'")),
               () -> assertEquals("low", SCANNER_LICENSE_THRESHOLD.defaultValue(), getAssertionMessage(SCANNER_LICENSE_THRESHOLD, "default value must be 'low'"))
     );
 
     assertAll("should be empty",
-              () -> assertEquals("", API_URL.defaultValue(), getAssertionMessage(API_URL, "default value must be empty")),
               () -> assertEquals("", API_TOKEN.defaultValue(), getAssertionMessage(API_TOKEN, "default value must be empty")),
               () -> assertEquals("", API_ORGANIZATION.defaultValue(), getAssertionMessage(API_ORGANIZATION, "default value must be empty"))
     );

--- a/snyk-sdk/src/main/java/io/snyk/sdk/Snyk.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/Snyk.java
@@ -63,5 +63,11 @@ public class Snyk {
       this.token = token;
       this.userAgent = DEFAULT_USER_AGENT;
     }
+
+    public Config(String baseUrl, String token, String userAgent) {
+      this.baseUrl = baseUrl;
+      this.token = token;
+      this.userAgent = userAgent;
+    }
   }
 }


### PR DESCRIPTION
This PR fix default user-agent for API client with the custom one.
Custom `User-Agent` header is `snyk-artifactory-plugin/<version>`