### PR TITLE
chore: load plugin version from property file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[snykSecurityPlugin.version]
+insert_final_newline = false

--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.version
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.version
@@ -1,0 +1,1 @@
+${revision}

--- a/core/src/main/java/io/snyk/plugins/artifactory/PropertyLoader.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/PropertyLoader.java
@@ -4,10 +4,18 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 final class PropertyLoader {
 
+  private static final String DIRECTORY_NOT_FOUND_ERROR_MESSAGE = "Directory '%s' not found";
+  private static final String FILE_NOT_FOUND_ERROR_MESSAGE = "File '%s' not found";
+
+  private static final String PLUGIN_VERSION_FILE = "snykSecurityPlugin.version";
   private static final String PROPERTY_FILE = "snykSecurityPlugin.properties";
 
   private PropertyLoader() {
@@ -16,12 +24,12 @@ final class PropertyLoader {
 
   static Properties loadProperties(@Nonnull File pluginsDirectory) throws IOException {
     if (!pluginsDirectory.exists()) {
-      throw new IOException("Directory '" + pluginsDirectory.getAbsolutePath() + "' not found");
+      throw new IOException(format(DIRECTORY_NOT_FOUND_ERROR_MESSAGE, pluginsDirectory.getAbsolutePath()));
     }
 
     File propertyFile = new File(pluginsDirectory, PROPERTY_FILE);
     if (!propertyFile.exists()) {
-      throw new IOException("File '" + propertyFile.getAbsolutePath() + "' not found");
+      throw new IOException(format(FILE_NOT_FOUND_ERROR_MESSAGE, propertyFile.getAbsolutePath()));
     }
 
     Properties properties = new Properties();
@@ -29,5 +37,22 @@ final class PropertyLoader {
       properties.load(fis);
     }
     return properties;
+  }
+
+  static String loadPluginVersion(@Nonnull File pluginsDirectory) throws IOException {
+    if (!pluginsDirectory.exists()) {
+      throw new IOException(format(DIRECTORY_NOT_FOUND_ERROR_MESSAGE, pluginsDirectory.getAbsolutePath()));
+    }
+
+    File libDirectory = new File(pluginsDirectory, "lib");
+    if (!libDirectory.exists()) {
+      throw new IOException(format(DIRECTORY_NOT_FOUND_ERROR_MESSAGE, libDirectory.getAbsolutePath()));
+    }
+    File pluginVersionFile = new File(libDirectory, PLUGIN_VERSION_FILE);
+    if (!pluginVersionFile.exists()) {
+      throw new IOException(format(FILE_NOT_FOUND_ERROR_MESSAGE, pluginVersionFile.getAbsolutePath()));
+    }
+
+    return new String(Files.readAllBytes(pluginVersionFile.toPath()), UTF_8);
   }
 }

--- a/distribution/src/assembly/distribution-docker.xml
+++ b/distribution/src/assembly/distribution-docker.xml
@@ -16,5 +16,10 @@
       <source>../core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.groovy</source>
       <outputDirectory>etc/plugins</outputDirectory>
     </file>
+    <file>
+      <source>../core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.version</source>
+      <outputDirectory>etc/plugins/lib</outputDirectory>
+      <filtered>true</filtered>
+    </file>
   </files>
 </assembly>

--- a/distribution/src/assembly/distribution.xml
+++ b/distribution/src/assembly/distribution.xml
@@ -20,5 +20,10 @@
       <source>../core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties</source>
       <outputDirectory>plugins</outputDirectory>
     </file>
+    <file>
+      <source>../core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.version</source>
+      <outputDirectory>plugins/lib</outputDirectory>
+      <filtered>true</filtered>
+    </file>
   </files>
 </assembly>


### PR DESCRIPTION
This PR adds following functionality:
- create custom user-agent header in form `snyk-artifactory-plugin/<released-plugin-version>`
- *released-plugin-version* will be generated from git tag during the release phase, in case of local development the value is `LOCAL-SHAPSHOT`.