### PR TITLE
docs: list 'none' value for vulnerability and license issue thresholds

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -27,9 +27,9 @@ snyk.api.organization=
 # Setting this property to "false" allows download of artifacts.
 # Default value: "true"
 snyk.scanner.block-on-api-failure=true
-# Global threshold for vulnerability issues. Valid values include "low", "medium", "high", "critical".
+# Global threshold for vulnerability issues. Valid values include "none", "low", "medium", "high", "critical".
 # Default value: "low"
 snyk.scanner.vulnerability.threshold=low
-# Global threshold for license issues. Valid values include "low", "medium", "high", "critical".
+# Global threshold for license issues. Valid values include "none", "low", "medium", "high", "critical".
 # Default value: "low"
 snyk.scanner.license.threshold=low


### PR DESCRIPTION
This PR documents using 'none' as vulnerability and license issue thresholds.
It was possible earlier but not present in property file.