### PR TITLE
Smoke tests

### DIFF
--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -1,0 +1,73 @@
+name: Smoke Tests
+on:
+  push:
+
+jobs:
+  smoke_tests:
+    name: Smoke tests @ Artifactory ${{ matrix.artifactory_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        artifactory_version: [7.2.0, 7.4.3, 7.7.8, 7.17.5, 7.19.9]
+
+    steps:
+      - name: Fetch sources
+        uses: actions/checkout@v2
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Configure build metadata
+        id: metadata
+        run: echo ::set-output name=tag::1.0.0
+
+      - name: Build plugin
+        env:
+          TEST_SNYK_TOKEN: ${{ secrets.TEST_SNYK_TOKEN }}
+          TEST_SNYK_ORG: ${{ secrets.TEST_SNYK_ORG }}
+        run: |
+          ./mvnw clean verify --show-version --batch-mode --no-transfer-progress --errors -Drevision=${{ steps.metadata.outputs.tag }}
+          cd ${GITHUB_WORKSPACE}/distribution/target
+          sha256sum artifactory-snyk-security-plugin-${{ steps.metadata.outputs.tag }}.zip > artifactory-snyk-security-plugin-${{ steps.metadata.outputs.tag }}.zip.sha256
+          unzip artifactory-snyk-security-plugin-${{ steps.metadata.outputs.tag }}.zip
+          chmod a+rwx -R plugins/
+          sed -i "s/snyk.api.token=/snyk.api.token=${TEST_SNYK_TOKEN}/" plugins/snykSecurityPlugin.properties
+          sed -i "s/snyk.api.organization=/snyk.api.organization=${TEST_SNYK_ORG}/" plugins/snykSecurityPlugin.properties
+
+      - name: Start the Artifactory container with Snyk plugin mounted
+        run: docker run -d --name artifactory -p 8082:8082 -v ${GITHUB_WORKSPACE}/distribution/target/plugins:/opt/jfrog/artifactory/var/etc/artifactory/plugins releases-docker.jfrog.io/jfrog/artifactory-pro:${{ matrix.artifactory_version }}
+
+      - name: Wait for Artifactory start
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: "http://localhost:8082/"
+          responseCode: 200
+          timeout: 120000
+          interval: 2000
+
+      - name: Save docker logs to file
+        uses: jwalton/gh-docker-logs@v1
+        with:
+          dest: "./logs"
+
+      - name: Find any Snyk plugin errors in docker logs
+        run: "! grep -Hrni snyk ./logs | grep -i error"
+
+      - name: Dump docker logs (on success)
+        uses: jwalton/gh-docker-logs@v1
+
+      - name: Dump docker logs (on failure)
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1


### PR DESCRIPTION
GitHub Action smoke tests for sanity checking different Artifactory versions

Lifted the plugin build part from the Release workflow

Currently failing with older versions, because they are not supported yet.