### PR TITLE
fix: fail on missing file info

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
@@ -24,13 +24,14 @@ class MavenScanner implements PackageScanner {
   }
 
   public Optional<TestResult> scan(FileLayoutInfo fileLayoutInfo) {
-    String organization = configurationModule.getProperty(API_ORGANIZATION);
     try {
-      var result = snykClient.testMaven(fileLayoutInfo.getOrganization(),
-        fileLayoutInfo.getModule(),
-        fileLayoutInfo.getBaseRevision(),
-        Optional.of(organization),
-        Optional.empty());
+      var result = snykClient.testMaven(
+        Optional.ofNullable(fileLayoutInfo.getOrganization()).orElseThrow(() -> new RuntimeException("Group ID not provided.")),
+        Optional.ofNullable(fileLayoutInfo.getModule()).orElseThrow(() -> new RuntimeException("Artifact ID not provided.")),
+        Optional.ofNullable(fileLayoutInfo.getBaseRevision()).orElseThrow(() -> new RuntimeException("Artifact Version not provided.")),
+        Optional.ofNullable(configurationModule.getProperty(API_ORGANIZATION)),
+        Optional.empty()
+      );
       if (result.isSuccessful()) {
         LOG.debug("testMaven response: {}", result.responseAsText.get());
         return result.get();

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/NpmScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/NpmScanner.java
@@ -24,11 +24,12 @@ class NpmScanner implements PackageScanner {
   }
 
   public Optional<TestResult> scan(FileLayoutInfo fileLayoutInfo) {
-    String organization = configurationModule.getProperty(API_ORGANIZATION);
     try {
-      var result = snykClient.testNpm(fileLayoutInfo.getModule(),
-        fileLayoutInfo.getBaseRevision(),
-        Optional.of(organization));
+      var result = snykClient.testNpm(
+        Optional.ofNullable(fileLayoutInfo.getModule()).orElseThrow(() -> new RuntimeException("Package name not provided.")),
+        Optional.ofNullable(fileLayoutInfo.getBaseRevision()).orElseThrow(() -> new RuntimeException("Package version not provided.")),
+        Optional.ofNullable(configurationModule.getProperty(API_ORGANIZATION))
+      );
       if (result.isSuccessful()) {
         LOG.debug("testNpm response: {}", result.responseAsText.get());
         return result.get();

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
@@ -25,11 +25,12 @@ class PythonScanner implements PackageScanner {
   }
 
   public Optional<TestResult> scan(FileLayoutInfo fileLayoutInfo) {
-    String organization = configurationModule.getProperty(API_ORGANIZATION);
     try {
-      SnykResult<TestResult> result = snykClient.testPip(fileLayoutInfo.getModule(),
-        fileLayoutInfo.getBaseRevision(),
-        Optional.of(organization));
+      SnykResult<TestResult> result = snykClient.testPip(
+        Optional.ofNullable(fileLayoutInfo.getModule()).orElseThrow(() -> new RuntimeException("Module name not provided.")),
+        Optional.ofNullable(fileLayoutInfo.getBaseRevision()).orElseThrow(() -> new RuntimeException("Module version not provided.")),
+        Optional.ofNullable(configurationModule.getProperty(API_ORGANIZATION))
+      );
       if (result.isSuccessful()) {
         LOG.debug("testPip response: {}", result.responseAsText.get());
         return result.get();

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/MavenScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/MavenScannerTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 public class MavenScannerTest {
   @Test
-  void canTestMavenPackage() throws Exception {
+  void shouldTestMavenPackage() throws Exception {
     Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
     Properties properties = new Properties();
     @Nonnull String org = System.getenv("TEST_SNYK_ORG");
@@ -33,8 +33,8 @@ public class MavenScannerTest {
     MavenScanner scanner = new MavenScanner(configurationModule, snykClient);
 
     FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
-    when(fileLayoutInfo.getOrganization()).thenReturn("com.fasterxml.jackson.core"); // corresponds to groupId
-    when(fileLayoutInfo.getModule()).thenReturn("jackson-databind"); // corresponds to artifactId
+    when(fileLayoutInfo.getOrganization()).thenReturn("com.fasterxml.jackson.core");
+    when(fileLayoutInfo.getModule()).thenReturn("jackson-databind");
     when(fileLayoutInfo.getBaseRevision()).thenReturn("2.9.8");
 
     Optional<TestResult> result = scanner.scan(fileLayoutInfo);
@@ -45,5 +45,71 @@ public class MavenScannerTest {
     assertEquals(47, actualResult.issues.vulnerabilities.size());
     assertEquals("maven", actualResult.packageManager);
     assertEquals(org, actualResult.organisation.id);
+  }
+
+  @Test
+  void shouldNotTestMavenPackage_WhenGroupIDNotProvided() throws Exception {
+    Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
+    Properties properties = new Properties();
+    @Nonnull String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    properties.put(API_ORGANIZATION.propertyKey(), org);
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    SnykClient snykClient = new SnykClient(config);
+    MavenScanner scanner = new MavenScanner(configurationModule, snykClient);
+
+    FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
+    when(fileLayoutInfo.getOrganization()).thenReturn(null);
+    when(fileLayoutInfo.getModule()).thenReturn("jackson-databind");
+    when(fileLayoutInfo.getBaseRevision()).thenReturn("2.9.8");
+
+    Optional<TestResult> result = scanner.scan(fileLayoutInfo);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void shouldNotTestMavenPackage_WhenArtifactIDNotProvided() throws Exception {
+    Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
+    Properties properties = new Properties();
+    @Nonnull String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    properties.put(API_ORGANIZATION.propertyKey(), org);
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    SnykClient snykClient = new SnykClient(config);
+    MavenScanner scanner = new MavenScanner(configurationModule, snykClient);
+
+    FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
+    when(fileLayoutInfo.getOrganization()).thenReturn("com.fasterxml.jackson.core");
+    when(fileLayoutInfo.getModule()).thenReturn(null);
+    when(fileLayoutInfo.getBaseRevision()).thenReturn("2.9.8");
+
+    Optional<TestResult> result = scanner.scan(fileLayoutInfo);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void shouldNotTestMavenPackage_WhenArtifactVersionNotProvided() throws Exception {
+    Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
+    Properties properties = new Properties();
+    @Nonnull String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    properties.put(API_ORGANIZATION.propertyKey(), org);
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    SnykClient snykClient = new SnykClient(config);
+    MavenScanner scanner = new MavenScanner(configurationModule, snykClient);
+
+    FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
+    when(fileLayoutInfo.getOrganization()).thenReturn("com.fasterxml.jackson.core");
+    when(fileLayoutInfo.getModule()).thenReturn("jackson-databind");
+    when(fileLayoutInfo.getBaseRevision()).thenReturn(null);
+
+    Optional<TestResult> result = scanner.scan(fileLayoutInfo);
+    assertFalse(result.isPresent());
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/NpmScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/NpmScannerTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 public class NpmScannerTest {
   @Test
-  void canTestNpmPackage() throws Exception {
+  void shouldTestNpmPackage() throws Exception {
     Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
     Properties properties = new Properties();
     @Nonnull String org = System.getenv("TEST_SNYK_ORG");
@@ -44,5 +44,47 @@ public class NpmScannerTest {
     assertEquals(5, actualResult.issues.vulnerabilities.size());
     assertEquals("npm", actualResult.packageManager);
     assertEquals(org, actualResult.organisation.id);
+  }
+
+  @Test
+  void shouldNotTestNpmPackage_WhenPackageNameNotProvided() throws Exception {
+    Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
+    Properties properties = new Properties();
+    @Nonnull String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    properties.put(API_ORGANIZATION.propertyKey(), org);
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    SnykClient snykClient = new SnykClient(config);
+    NpmScanner scanner = new NpmScanner(configurationModule, snykClient);
+
+    FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
+    when(fileLayoutInfo.getModule()).thenReturn(null);
+    when(fileLayoutInfo.getBaseRevision()).thenReturn("4.17.15");
+
+    Optional<TestResult> result = scanner.scan(fileLayoutInfo);
+    Assertions.assertFalse(result.isPresent());
+  }
+
+  @Test
+  void shouldNotTestNpmPackage_WhenPackageVersionNotProvided() throws Exception {
+    Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
+    Properties properties = new Properties();
+    @Nonnull String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    properties.put(API_ORGANIZATION.propertyKey(), org);
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    SnykClient snykClient = new SnykClient(config);
+    NpmScanner scanner = new NpmScanner(configurationModule, snykClient);
+
+    FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
+    when(fileLayoutInfo.getModule()).thenReturn("lodash");
+    when(fileLayoutInfo.getBaseRevision()).thenReturn(null);
+
+    Optional<TestResult> result = scanner.scan(fileLayoutInfo);
+    Assertions.assertFalse(result.isPresent());
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 public class PythonScannerTest {
   @Test
-  void canTestPipPackage() throws Exception {
+  void shouldTestPipPackage() throws Exception {
     Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
     Properties properties = new Properties();
     @Nonnull String org = System.getenv("TEST_SNYK_ORG");
@@ -41,8 +41,51 @@ public class PythonScannerTest {
     TestResult actualResult = result.get();
     assertFalse(actualResult.success);
     assertEquals(1, actualResult.dependencyCount);
-    assertEquals(2, actualResult.issues.vulnerabilities.size());
+    assertEquals(3, actualResult.issues.vulnerabilities.size());
     assertEquals("pip", actualResult.packageManager);
     assertEquals(org, actualResult.organisation.id);
   }
+
+  @Test
+  void shouldNotTestPipPackage_WhenModuleNameNotProvided() throws Exception {
+    Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
+    Properties properties = new Properties();
+    @Nonnull String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    properties.put(API_ORGANIZATION.propertyKey(), org);
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    SnykClient snykClient = new SnykClient(config);
+    PythonScanner scanner = new PythonScanner(configurationModule, snykClient);
+
+    FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
+    when(fileLayoutInfo.getModule()).thenReturn(null);
+    when(fileLayoutInfo.getBaseRevision()).thenReturn("1.25.7");
+
+    Optional<TestResult> result = scanner.scan(fileLayoutInfo);
+    Assertions.assertFalse(result.isPresent());
+  }
+
+  @Test
+  void shouldNotTestPipPackage_WhenModuleVersionNotProvided() throws Exception {
+    Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));
+    Properties properties = new Properties();
+    @Nonnull String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    properties.put(API_ORGANIZATION.propertyKey(), org);
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    SnykClient snykClient = new SnykClient(config);
+    PythonScanner scanner = new PythonScanner(configurationModule, snykClient);
+
+    FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
+    when(fileLayoutInfo.getModule()).thenReturn("urllib3");
+    when(fileLayoutInfo.getBaseRevision()).thenReturn(null);
+
+    Optional<TestResult> result = scanner.scan(fileLayoutInfo);
+    Assertions.assertFalse(result.isPresent());
+  }
+
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -326,7 +326,7 @@ public class ScannerModuleTest {
     TestResult tr = testResultCaptor.getValue();
     assertFalse(tr.success);
     assertEquals(1, tr.dependencyCount);
-    assertEquals(2, tr.issues.vulnerabilities.size());
+    assertEquals(3, tr.issues.vulnerabilities.size());
     assertEquals("pip", tr.packageManager);
     assertEquals(testSetup.org, tr.organisation.id);
 


### PR DESCRIPTION
Currently we assume when provided file info that all parameters are available. This leads to us sending `null` to the registry. For example:

```
/api/v1/test/npm/null/null
```

This PR fixes this by failing when any of these values are null and providing that detail in the logs.