### PR TITLE
feat: use package type for choosing scanner

### DIFF
--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -23,38 +23,57 @@ import static org.mockito.Mockito.*;
 public class ScannerModuleTest {
 
   @Test
-  void testGetScannerForPackageType() {
+  void getScannerForPackageType_shouldReturnMavenScanner() {
     Properties properties = new Properties();
     ConfigurationModule configurationModule = new ConfigurationModule(properties);
 
     ScannerModule sm = new ScannerModule(
       configurationModule,
       mock(Repositories.class),
-      mock(SnykClient.class));
+      mock(SnykClient.class)
+    );
 
-    assertTrue(
-      sm.getScannerForPackageType("myArtifact.jar").get()
-        instanceof MavenScanner);
+    assertTrue(sm.getScannerForPackageType("maven").get() instanceof MavenScanner);
+  }
 
-    assertTrue(
-      sm.getScannerForPackageType("myArtifact.tgz").get()
-        instanceof NpmScanner);
+  @Test
+  void getScannerForPackageType_shouldReturnNPMScanner() {
+    Properties properties = new Properties();
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
 
-    assertTrue(
-      sm.getScannerForPackageType("myArtifact.whl").get()
-        instanceof PythonScanner);
+    ScannerModule sm = new ScannerModule(
+      configurationModule,
+      mock(Repositories.class),
+      mock(SnykClient.class)
+    );
 
-    assertTrue(
-      sm.getScannerForPackageType("myArtifact.tar.gz").get()
-        instanceof PythonScanner);
+    assertTrue(sm.getScannerForPackageType("npm").get() instanceof NpmScanner);
+  }
 
-    assertTrue(
-      sm.getScannerForPackageType("myArtifact.zip").get()
-        instanceof PythonScanner);
+  @Test
+  void getScannerForPackageType_shouldReturnPythonScanner() {
+    Properties properties = new Properties();
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
 
-    assertTrue(
-      sm.getScannerForPackageType("myArtifact.egg").get()
-        instanceof PythonScanner);
+    ScannerModule sm = new ScannerModule(
+      configurationModule,
+      mock(Repositories.class),
+      mock(SnykClient.class)
+    );
+
+    assertTrue(sm.getScannerForPackageType("pypi").get() instanceof PythonScanner);
+  }
+
+  @Test
+  void getScannerForPackageType_shouldHaveNoScannerForUnknownPackageType() {
+    Properties properties = new Properties();
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    ScannerModule sm = new ScannerModule(
+      configurationModule,
+      mock(Repositories.class),
+      mock(SnykClient.class)
+    );
 
     assertTrue(sm.getScannerForPackageType("unknown").isEmpty());
   }


### PR DESCRIPTION
File extensions aren't specific enough and may cause the wrong assumptions, especially for all of the package types that this plugin doesn't cover.

I found the possible `repoConfig.getPackageType()` values by running downloads through the plugin for those repos and logging out the value.

There's also `repoConfig.isEnableNpmSupport` and `repoConfig.isEnablePypiSupport` but these are limited and there's no "Maven" equivalent.

# To Do

- [ ] Fix tests
- [x] Wait for improved package name/version parsing #38
- [ ] The current extension matching approach may mean it gave us Gradle and SBT support for free (JAR files). This needs to be confirmed and if so, needs to be maintained in this PR.