### PR TITLE
refactor: handle api failures explicitly

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/exception/SnykAPIFailureException.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/exception/SnykAPIFailureException.java
@@ -1,0 +1,14 @@
+package io.snyk.plugins.artifactory.exception;
+
+import io.snyk.sdk.api.v1.SnykResult;
+import io.snyk.sdk.model.TestResult;
+
+public class SnykAPIFailureException extends RuntimeException {
+  public SnykAPIFailureException(SnykResult<TestResult> result) {
+    super("Snyk API request was not successful. (" + result.statusCode + ")");
+  }
+
+  public SnykAPIFailureException(Exception cause) {
+    super("Snyk API request encountered an unexpected error.", cause);
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageScanner.java
@@ -4,8 +4,6 @@ import io.snyk.sdk.model.TestResult;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 
-import java.util.Optional;
-
 interface PackageScanner {
-  Optional<TestResult> scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath);
+  TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath);
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -57,20 +57,8 @@ public class ScannerModule {
     }
 
     var scanner = maybeScanner.get();
-    var maybeTestResult = scanner.scan(fileLayoutInfo, repoPath);
-    if (maybeTestResult.isEmpty()) {
-      final String blockOnApiFailurePropertyKey = SCANNER_BLOCK_ON_API_FAILURE.propertyKey();
-      final String blockOnApiFailure = configurationModule.getPropertyOrDefault(SCANNER_BLOCK_ON_API_FAILURE);
-      String message = format("Artifact '%s' could not be scanned because Snyk API is not available", repoPath);
-      if ("true".equals(blockOnApiFailure)) {
-        throw new CancelException(message, 500);
-      }
-      LOG.warn(message);
-      LOG.warn("Property '{}' is false, so allowing download: '{}'", blockOnApiFailurePropertyKey, repoPath);
-      throw new CannotScanException("Snyk API request failed.");
-    }
+    TestResult testResult = scanner.scan(fileLayoutInfo, repoPath);
 
-    TestResult testResult = maybeTestResult.get();
     updateProperties(repoPath, testResult);
     validateVulnerabilityIssues(testResult, repoPath);
     validateLicenseIssues(testResult, repoPath);

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -44,21 +44,13 @@ public class ScannerModule {
   }
 
   public void scanArtifact(@Nonnull RepoPath repoPath) {
+    PackageScanner scanner = Optional.ofNullable(repoPath.getPath())
+      .flatMap(this::getScannerForPackageType)
+      .orElseThrow(() -> new CannotScanException("Artifact not supported."));
+
     FileLayoutInfo fileLayoutInfo = repositories.getLayoutInfo(repoPath);
 
-    String path = repoPath.getPath();
-    if (path == null) {
-      throw new CannotScanException("Artifact path is not available");
-    }
-
-    Optional<PackageScanner> maybeScanner = getScannerForPackageType(path);
-    if (maybeScanner.isEmpty()) {
-      throw new CannotScanException("Artifact not supported.");
-    }
-
-    var scanner = maybeScanner.get();
     TestResult testResult = scanner.scan(fileLayoutInfo, repoPath);
-
     updateProperties(repoPath, testResult);
     validateVulnerabilityIssues(testResult, repoPath);
     validateLicenseIssues(testResult, repoPath);

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/MavenScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/MavenScannerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
 import java.util.Properties;
 
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
@@ -39,16 +38,14 @@ public class MavenScannerTest {
     when(fileLayoutInfo.getModule()).thenReturn("jackson-databind");
     when(fileLayoutInfo.getBaseRevision()).thenReturn("2.9.8");
 
-    Optional<TestResult> result = scanner.scan(fileLayoutInfo, repoPath);
-    Assertions.assertTrue(result.isPresent());
-    TestResult actualResult = result.get();
-    assertFalse(actualResult.success); // false because it has vulns
-    assertEquals(3, actualResult.dependencyCount);
-    assertEquals(47, actualResult.issues.vulnerabilities.size());
-    assertEquals("maven", actualResult.packageManager);
-    assertEquals(org, actualResult.organisation.id);
+    TestResult result = scanner.scan(fileLayoutInfo, repoPath);
+    assertFalse(result.success); // false because it has vulns
+    assertEquals(3, result.dependencyCount);
+    assertEquals(47, result.issues.vulnerabilities.size());
+    assertEquals("maven", result.packageManager);
+    assertEquals(org, result.organisation.id);
     assertEquals("https://snyk.io/vuln/maven:com.fasterxml.jackson.core%3Ajackson-databind@2.9.8",
-      actualResult.packageDetailsURL
+      result.packageDetailsURL
     );
   }
 

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/NpmScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/NpmScannerTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
 import java.util.Properties;
 
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
@@ -36,15 +35,13 @@ public class NpmScannerTest {
     when(repoPath.toString()).thenReturn("npm:lodash/-/lodash-4.17.15.tgz");
     FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
 
-    Optional<TestResult> result = scanner.scan(fileLayoutInfo, repoPath);
-    Assertions.assertTrue(result.isPresent());
-    TestResult actualResult = result.get();
-    assertFalse(actualResult.success);
-    assertEquals(1, actualResult.dependencyCount);
-    assertEquals(5, actualResult.issues.vulnerabilities.size());
-    assertEquals("npm", actualResult.packageManager);
-    assertEquals(org, actualResult.organisation.id);
-    assertEquals("https://snyk.io/vuln/npm:lodash@4.17.15", actualResult.packageDetailsURL);
+    TestResult result = scanner.scan(fileLayoutInfo, repoPath);
+    assertFalse(result.success);
+    assertEquals(1, result.dependencyCount);
+    assertEquals(5, result.issues.vulnerabilities.size());
+    assertEquals("npm", result.packageManager);
+    assertEquals(org, result.organisation.id);
+    assertEquals("https://snyk.io/vuln/npm:lodash@4.17.15", result.packageDetailsURL);
   }
 
   @Test

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
 import java.util.Properties;
 
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
@@ -38,15 +37,13 @@ public class PythonScannerTest {
     when(fileLayoutInfo.getModule()).thenReturn("urllib3");
     when(fileLayoutInfo.getBaseRevision()).thenReturn("1.25.7");
 
-    Optional<TestResult> result = scanner.scan(fileLayoutInfo, repoPath);
-    assertTrue(result.isPresent());
-    TestResult actualResult = result.get();
-    assertFalse(actualResult.success);
-    assertEquals(1, actualResult.dependencyCount);
-    assertEquals(3, actualResult.issues.vulnerabilities.size());
-    assertEquals("pip", actualResult.packageManager);
-    assertEquals(org, actualResult.organisation.id);
-    assertEquals("https://snyk.io/vuln/pip:urllib3@1.25.7", actualResult.packageDetailsURL);
+    TestResult result = scanner.scan(fileLayoutInfo, repoPath);
+    assertFalse(result.success);
+    assertEquals(1, result.dependencyCount);
+    assertEquals(3, result.issues.vulnerabilities.size());
+    assertEquals("pip", result.packageManager);
+    assertEquals(org, result.organisation.id);
+    assertEquals("https://snyk.io/vuln/pip:urllib3@1.25.7", result.packageDetailsURL);
   }
 
   @Test


### PR DESCRIPTION
Note: This merges into #38 

The use or optionals in the package scanners is a bit confusing as there are multiple failure scenarios being aggregated into a single Optional. Optionals for this part of the code isn't ideal as we lose information. Ideally we'd have a `Result<Value, Error>` sort of approach, but that'll require a lot more work and refactoring.

I think it's best if we throw at the scanner level and let the plugin handle it (using configuration). This will bring us closer to a state where the Scanners don't worry about handle various user-visible failures, that'll be the `SnykPlugin`'s job.