### PR TITLE
fix: encode path and query params

### DIFF
--- a/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
@@ -9,12 +9,15 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class SnykClient {
   private Snyk.Config config;
@@ -46,7 +49,10 @@ public class SnykClient {
 
   public SnykResult<NotificationSettings> getNotificationSettings(String org) throws java.io.IOException, java.lang.InterruptedException {
     HttpRequest request = SnykHttpRequestBuilder.create(config)
-      .withPath(String.format("user/me/notification-settings/org/%s", org))
+      .withPath(String.format(
+        "user/me/notification-settings/org/%s",
+        URLEncoder.encode(org, UTF_8)
+      ))
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, NotificationSettings.class);
@@ -54,7 +60,12 @@ public class SnykClient {
 
   public SnykResult<TestResult> testMaven(String groupId, String artifactId, String version, Optional<String> organisation, Optional<String> repository) throws IOException, InterruptedException {
     HttpRequest request = SnykHttpRequestBuilder.create(config)
-      .withPath(String.format("test/maven/%s/%s/%s", groupId, artifactId, version))
+      .withPath(String.format(
+        "test/maven/%s/%s/%s",
+        URLEncoder.encode(groupId, UTF_8),
+        URLEncoder.encode(artifactId, UTF_8),
+        URLEncoder.encode(version, UTF_8)
+      ))
       .withOptionalQueryParam("org", organisation)
       .withOptionalQueryParam("repository", repository)
       .build();
@@ -64,7 +75,11 @@ public class SnykClient {
 
   public SnykResult<TestResult> testNpm(String packageName, String version, Optional<String> organisation) throws IOException, InterruptedException {
     HttpRequest request = SnykHttpRequestBuilder.create(config)
-      .withPath(String.format("test/npm/%s/%s", packageName, version))
+      .withPath(String.format(
+        "test/npm/%s/%s",
+        URLEncoder.encode(packageName, UTF_8),
+        URLEncoder.encode(version, UTF_8)
+      ))
       .withOptionalQueryParam("org", organisation)
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -73,7 +88,11 @@ public class SnykClient {
 
   public SnykResult<TestResult> testRubyGems(String gemName, String version, Optional<String> organisation) throws IOException, InterruptedException {
     HttpRequest request = SnykHttpRequestBuilder.create(config)
-      .withPath(String.format("test/rubygems/%s/%s", gemName, version))
+      .withPath(String.format(
+        "test/rubygems/%s/%s",
+        URLEncoder.encode(gemName, UTF_8),
+        URLEncoder.encode(version, UTF_8)
+      ))
       .withOptionalQueryParam("org", organisation)
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -82,7 +101,11 @@ public class SnykClient {
 
   public SnykResult<TestResult> testPip(String packageName, String version, Optional<String> organisation) throws IOException, InterruptedException {
     HttpRequest request = SnykHttpRequestBuilder.create(config)
-      .withPath(String.format("test/pip/%s/%s", packageName, version))
+      .withPath(String.format(
+        "test/pip/%s/%s",
+        URLEncoder.encode(packageName, UTF_8),
+        URLEncoder.encode(version, UTF_8)
+      ))
       .withOptionalQueryParam("org", organisation)
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());

--- a/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykHttpRequestBuilder.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykHttpRequestBuilder.java
@@ -3,11 +3,14 @@ package io.snyk.sdk.api.v1;
 import io.snyk.sdk.Snyk;
 
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.util.HashMap;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 
 public class SnykHttpRequestBuilder {
@@ -34,9 +37,7 @@ public class SnykHttpRequestBuilder {
   }
 
   public SnykHttpRequestBuilder withOptionalQueryParam(String key, Optional<String> value) {
-    if (value.isPresent()) {
-      this.queryParams.put(key, value.get());
-    }
+    value.ifPresent(v -> this.queryParams.put(key, v));
     return this;
   }
 
@@ -49,7 +50,10 @@ public class SnykHttpRequestBuilder {
     String queryString = this.queryParams
       .entrySet()
       .stream()
-      .map((entry) -> String.format("%s=%s", entry.getKey(), entry.getValue()))
+      .map((entry) -> String.format(
+        "%s=%s",
+        URLEncoder.encode(entry.getKey(), UTF_8),
+        URLEncoder.encode(entry.getValue(), UTF_8)))
       .collect(Collectors.joining("&"));
 
     if (!queryString.isBlank()) {


### PR DESCRIPTION
I noticed packages like `@snyk/protect` weren't being scanned and failed with a 422 error from Registry. This is caused by the lack of URL encoding when creating paths.

e.g.

```
/test/npm/@snyk/protect/1.700.0
```

should be

```
/test/npm/%40snyk%2Fprotect/1.700.0
```

so that it matches the correct route on registry.