### PR TITLE
feat: allow individual scanners to be disabled

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -33,3 +33,12 @@ snyk.scanner.vulnerability.threshold=low
 # Global threshold for license issues. Valid values include "none", "low", "medium", "high", "critical".
 # Default value: "low"
 snyk.scanner.license.threshold=low
+# Enable Maven repository scanning.
+# Default value: "true"
+snyk.scanner.packageType.maven=true
+# Enable NPM repository scanning.
+# Default value: "true"
+snyk.scanner.packageType.npm=true
+# Enable PyPi repository scanning.
+# Default value: "true"
+snyk.scanner.packageType.pypi=true

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -11,7 +11,10 @@ public enum PluginConfiguration implements Configuration {
   // scanner module
   SCANNER_BLOCK_ON_API_FAILURE("snyk.scanner.block-on-api-failure", "true"),
   SCANNER_VULNERABILITY_THRESHOLD("snyk.scanner.vulnerability.threshold", "low"),
-  SCANNER_LICENSE_THRESHOLD("snyk.scanner.license.threshold", "low");
+  SCANNER_LICENSE_THRESHOLD("snyk.scanner.license.threshold", "low"),
+  SCANNER_PACKAGE_TYPE_MAVEN("snyk.scanner.packageType.maven", "true"),
+  SCANNER_PACKAGE_TYPE_NPM("snyk.scanner.packageType.npm", "true"),
+  SCANNER_PACKAGE_TYPE_PYPI("snyk.scanner.packageType.pypi", "true");
 
   private final String propertyKey;
   private final String defaultValue;

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.*;
-import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_BLOCK_ON_API_FAILURE;
+import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.*;
 import static io.snyk.sdk.util.Predicates.distinctByKey;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -79,11 +79,26 @@ public class ScannerModule {
 
   protected Optional<PackageScanner> getScannerForPackageType(String path) {
     if (path.endsWith(".jar")) {
-      return Optional.of(mavenScanner);
+      if (configurationModule.getPropertyOrDefault(SCANNER_PACKAGE_TYPE_MAVEN).equals("true")) {
+        return Optional.of(mavenScanner);
+      } else {
+        LOG.debug("Path will not be scanned. Maven repository scanning is disabled. Path: {}", path);
+        return Optional.empty();
+      }
     } else if (path.endsWith(".tgz")) {
-      return Optional.of(npmScanner);
+      if (configurationModule.getPropertyOrDefault(SCANNER_PACKAGE_TYPE_NPM).equals("true")) {
+        return Optional.of(npmScanner);
+      } else {
+        LOG.debug("Path will not be scanned. NPM repository scanning is disabled. Path: {}", path);
+        return Optional.empty();
+      }
     } else if (path.endsWith(".whl") || path.endsWith(".tar.gz") || path.endsWith(".zip") || path.endsWith(".egg")) {
-      return Optional.of(pythonScanner);
+      if (configurationModule.getPropertyOrDefault(SCANNER_PACKAGE_TYPE_PYPI).equals("true")) {
+        return Optional.of(pythonScanner);
+      } else {
+        LOG.debug("Path will not be scanned. PyPi repository scanning is disabled. Path: {}", path);
+        return Optional.empty();
+      }
     } else {
       return Optional.empty();
     }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mockito;
 import javax.annotation.Nonnull;
 import java.util.Properties;
 
-import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
+import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -59,6 +59,24 @@ public class ScannerModuleTest {
     assertTrue(sm.getScannerForPackageType("unknown").isEmpty());
   }
 
+  @Test
+  void testGetScannerForPackageType_shouldBeEmptyForDisabledScanners() {
+    Properties properties = new Properties();
+    properties.put(SCANNER_PACKAGE_TYPE_MAVEN.propertyKey(), "false");
+    properties.put(SCANNER_PACKAGE_TYPE_NPM.propertyKey(), "false");
+    properties.put(SCANNER_PACKAGE_TYPE_PYPI.propertyKey(), "false");
+    ConfigurationModule configurationModule = new ConfigurationModule(properties);
+
+    ScannerModule sm = new ScannerModule(
+      configurationModule,
+      mock(Repositories.class),
+      mock(SnykClient.class)
+    );
+
+    assertTrue(sm.getScannerForPackageType("myArtifact.jar").isEmpty());
+    assertTrue(sm.getScannerForPackageType("myArtifact.tgz").isEmpty());
+    assertTrue(sm.getScannerForPackageType("myArtifact.whl").isEmpty());
+  }
 
   ScanTestSetup createScannerSpyModuleForTest(FileLayoutInfo fileLayoutInfo) throws Exception {
     Snyk.Config config = new Snyk.Config(System.getenv("TEST_SNYK_TOKEN"));


### PR DESCRIPTION
Currently, all scanners are available. But users may want to disable some if they're having issues with them or don't want everything to be scanned.