### PR TITLE
fix: keep artifact issues updated

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -1,5 +1,6 @@
 package io.snyk.plugins.artifactory.scanner;
 
+import io.snyk.plugins.artifactory.configuration.ArtifactProperty;
 import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
 import io.snyk.plugins.artifactory.configuration.PluginConfiguration;
 import io.snyk.plugins.artifactory.exception.CannotScanException;
@@ -89,19 +90,21 @@ public class ScannerModule {
   }
 
   protected void updateProperties(RepoPath repoPath, TestResult testResult) {
-    String issueVulnerabilitiesProperty = repositories.getProperty(repoPath, ISSUE_VULNERABILITIES.propertyKey());
-    if (issueVulnerabilitiesProperty != null && !issueVulnerabilitiesProperty.isEmpty()) {
-      LOG.debug("Skip updating properties for already scanned artifact: {}", repoPath);
-      return;
-    }
-
     repositories.setProperty(repoPath, ISSUE_VULNERABILITIES.propertyKey(), getIssuesAsFormattedString(testResult.issues.vulnerabilities));
-    repositories.setProperty(repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD.propertyKey(), "false");
-    repositories.setProperty(repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO.propertyKey(), "");
     repositories.setProperty(repoPath, ISSUE_LICENSES.propertyKey(), getIssuesAsFormattedString(testResult.issues.licenses));
-    repositories.setProperty(repoPath, ISSUE_LICENSES_FORCE_DOWNLOAD.propertyKey(), "false");
-    repositories.setProperty(repoPath, ISSUE_LICENSES_FORCE_DOWNLOAD_INFO.propertyKey(), "");
     repositories.setProperty(repoPath, ISSUE_URL.propertyKey(), testResult.packageDetailsURL);
+
+    setDefaultArtifactProperty(repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD, "false");
+    setDefaultArtifactProperty(repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO, "");
+    setDefaultArtifactProperty(repoPath, ISSUE_LICENSES_FORCE_DOWNLOAD, "false");
+    setDefaultArtifactProperty(repoPath, ISSUE_LICENSES_FORCE_DOWNLOAD_INFO, "");
+  }
+
+  private void setDefaultArtifactProperty(RepoPath repoPath, ArtifactProperty property, String value) {
+    String key = property.propertyKey();
+    if (!repositories.hasProperty(repoPath, key)) {
+      repositories.setProperty(repoPath, key, value);
+    }
   }
 
   private String getIssuesAsFormattedString(@Nonnull List<? extends Issue> issues) {


### PR DESCRIPTION
Note: This is branched off #38 

Artifact properties currently aren't updated. That means if an artifact has 1 vuln previously and now there are 2 new vulns, we'll block on them, but the properties won't be updated to reflect the new vulns. It'll still show 1. This PR fixed that so we always update vuln details.

The other artifact properties seem to be user-defined so those are still only set once to avoid overwriting them. This may have been the original intention. The "force download" feature in general seems to be incomplete as we don't use it in the ScannerModule to avoid blocking downloads.