### PR TITLE
chore: remove misleading warning logging

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
@@ -60,10 +60,6 @@ class PythonScanner implements PackageScanner {
   }
 
   public TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
-    if (!fileLayoutInfo.isValid()) {
-      LOG.warn("Artifact '{}' file layout info is not valid.", repoPath);
-    }
-
     ModuleURLDetails details = getModuleDetailsFromFileLayoutInfo(fileLayoutInfo)
       .orElseGet(() -> getModuleDetailsFromUrl(repoPath.toString())
         .orElseThrow(() -> new CannotScanException("Module details not provided.")));


### PR DESCRIPTION
PyPi file layouts may often be invalid but since we fallback to regex parsing, this is usually not a problem.