### PR TITLE
feat: reduce logging and use debug levels

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
@@ -34,10 +34,6 @@ class MavenScanner implements PackageScanner {
   }
 
   public TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
-    if (!fileLayoutInfo.isValid()) {
-      LOG.warn("Artifact '{}' file layout info is not valid.", repoPath);
-    }
-
     String groupID = Optional.ofNullable(fileLayoutInfo.getOrganization())
       .orElseThrow(() -> new CannotScanException("Group ID not provided."));
     String artifactID = Optional.ofNullable(fileLayoutInfo.getModule())


### PR DESCRIPTION
We're logging too much, especially since we won't be able to scan most artifacts. I've also removed stacktraces for API failures are they're huge and mostly useless since it's all internal.