### PR TITLE
fix: fallback to default license threshold

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -168,7 +168,7 @@ public class ScannerModule {
       return;
     }
 
-    Severity licensesThreshold = Severity.of(configurationModule.getProperty(PluginConfiguration.SCANNER_LICENSE_THRESHOLD));
+    Severity licensesThreshold = Severity.of(configurationModule.getPropertyOrDefault(PluginConfiguration.SCANNER_LICENSE_THRESHOLD));
     if (licensesThreshold == Severity.LOW) {
       if (!testResult.issues.licenses.isEmpty()) {
         throw new CancelException(format("Artifact has license issues. %s", repoPath), 403);


### PR DESCRIPTION
`validateLicenseIssues` should use `getPropertyOrDefault` just like `validateVulnerabilityIssues` does. Otherwise if the user doesn't set a value, it will be `null` and so never match (similar to `none`) rather the supposed default `low`.