### PR TITLE
feat: cache results

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -36,7 +36,7 @@ snyk.api.organization=
 #snyk.api.trustAllCertificates=false
 
 # By default, if Snyk API hasn't responded within a duration of 60 seconds, the request will be cancelled.
-# This property lets you customise the timeout duration in milliseconds.
+# This property lets you customise the timeout duration (in milliseconds).
 # Default: "60000"
 #snyk.api.timeout=60000
 
@@ -49,6 +49,11 @@ snyk.api.organization=
 # Accepts: "true", "false"
 # Default: "false"
 #snyk.scanner.block-on-api-failure=false
+
+# By default, an artifact is scanned again after 24 hours has passed since its previous scan.
+# This property lets you customise the duration (in milliseconds) to wait before scanning an artifact again.
+# Default: "86400000" (24 hours)
+#snyk.scanner.cache.duration=86400000
 
 # Global threshold for vulnerability issues.
 # Accepts: "none", "low", "medium", "high", "critical"

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/ArtifactProperty.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/ArtifactProperty.java
@@ -7,7 +7,8 @@ public enum ArtifactProperty {
   ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO("snyk.issue.vulnerabilities.forceDownload.info"),
   ISSUE_LICENSES("snyk.issue.licenses"),
   ISSUE_LICENSES_FORCE_DOWNLOAD("snyk.issue.licenses.forceDownload"),
-  ISSUE_LICENSES_FORCE_DOWNLOAD_INFO("snyk.issue.licenses.forceDownload.info");
+  ISSUE_LICENSES_FORCE_DOWNLOAD_INFO("snyk.issue.licenses.forceDownload.info"),
+  ISSUE_UPDATED_AT("snyk.issue.updatedAt");
 
   private final String propertyKey;
 

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -14,6 +14,7 @@ public enum PluginConfiguration implements Configuration {
 
   // scanner module
   SCANNER_BLOCK_ON_API_FAILURE("snyk.scanner.block-on-api-failure", "false"),
+  SCANNER_CACHE_DURATION("snyk.scanner.cache.duration", "86400000"),
   SCANNER_VULNERABILITY_THRESHOLD("snyk.scanner.vulnerability.threshold", "low"),
   SCANNER_LICENSE_THRESHOLD("snyk.scanner.license.threshold", "low"),
   SCANNER_PACKAGE_TYPE_MAVEN("snyk.scanner.packageType.maven", "true"),

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -89,6 +90,7 @@ public class ScannerModule {
     repositories.setProperty(repoPath, ISSUE_VULNERABILITIES.propertyKey(), getSeverityCountsAsFormattedString(vulnCounts));
     repositories.setProperty(repoPath, ISSUE_LICENSES.propertyKey(), getSeverityCountsAsFormattedString(licenseCounts));
     repositories.setProperty(repoPath, ISSUE_URL.propertyKey(), testResult.packageDetailsURL);
+    repositories.setProperty(repoPath, ISSUE_UPDATED_AT.propertyKey(), Instant.now().toString());
 
     setDefaultArtifactProperty(repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD, "false");
     setDefaultArtifactProperty(repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO, "");

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -24,6 +24,7 @@ import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.*;
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.*;
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_PACKAGE_TYPE_PYPI;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.*;
 
 public class ScannerModuleTest {
@@ -163,6 +164,8 @@ public class ScannerModuleTest {
       .setProperty(repoPath, ISSUE_LICENSES.propertyKey(), "0 critical, 0 high, 0 medium, 0 low");
     verify(testSetup.repositories)
       .setProperty(repoPath, ISSUE_URL.propertyKey(), "https://snyk.io/test/npm/minimist/1.2.5");
+    verify(testSetup.repositories)
+      .setProperty(eq(repoPath), eq(ISSUE_UPDATED_AT.propertyKey()), matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{6}Z"));
   }
 
   @Test


### PR DESCRIPTION
These commits are from a while back, but I thought it's worth making a PR for the record.

To reduce API calls (slow, expensive), this PR adds a cache step to artifact scanning. Essentially, it reuses scan results from the artifact's properties if they were recently updated (duration is configurable). This avoids the need to re-scan artifacts and make API calls on every trigger.