### PR TITLE
[SUP-926] Performance optimization of scanning endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,22 @@ mvn install -DskipTests
 Will probably work. Per default, you'll find a baked `.zip`
 in `~/.m2/repository/io/snyk/plugins/artifactory-snyk-security-plugin/LOCAL-SNAPSHOT`.
 
-Edit the `.properties` file to something like:
+Unzip it. Inside is a `.groovy` file, a `.properties` file, as well as the actual `.jar` inside `/lib`.
+
+Edit the `.properties`, add something like this to the properties for a minimum working solution:
 
 ```
 snyk.api.token=<INSERT_TOKEN>
 snyk.api.organization=<INSERT_ORG_ID>
+```
+
+Also, if you want to test against your local Registry, but you're running on Docker:
+
+```
 snyk.api.url=http://host.docker.internal:8000/api/v1/
 ```
 
-The latter if you want to debug against a local registry. At least if you're on OSX, you cannot probe
-against `localhost` from within a Docker container.
+At least if you're on OSX, you cannot probe against `localhost` from within a Docker container.
 
 Also, remember to activate some of the scanners depending on what you're debugging:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mvn install -DskipTests
 ```
 
 Will probably work. Per default, you'll find a baked `.zip`
-in `~/.m2/repository/io/snyk/plugins/artifactory-snyk-security-plugin/LOCAL-SNAPSHOT`.
+in `~/.m2/repository/io/snyk/plugins/artifactory/distribution/LOCAL-SNAPSHOT`.
 
 Unzip it. Inside is a `.groovy` file, a `.properties` file, as well as the actual `.jar` inside `/lib`.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,89 @@
 # Artifactory Gatekeeper plugin
 
-For information about the Artifactory Gatekeeper plugin, see the Snyk user docs, [Artifactory Gatekeeper plugin](https://docs.snyk.io/integrations/private-registry-gatekeeper-plugins/artifactory-gatekeeper-plugin-overview).
+For information about the Artifactory Gatekeeper plugin, see the Snyk user
+docs, [Artifactory Gatekeeper plugin](https://docs.snyk.io/integrations/private-registry-gatekeeper-plugins/artifactory-gatekeeper-plugin-overview).
+
+## Setup local development environment
+
+### Download an Artifactory Docker image:
+
+```
+docker pull releases-docker.jfrog.io/jfrog/artifactory-pro:latest
+```
+
+Does not have to be `pro`, but in this example we'll do it.
+
+### Create a `$JFROG_HOME` folder
+
+```
+mkdir -p ~/.jfrog/artifactory/var/
+```
+
+Export it to your environment for ease of use
+
+```
+echo export JFROG_HOME=~/.jfrog >> ~/.zshrc
+```
+
+### Build the plugin
+
+Depends a lot on your system. But something like
+
+```
+mvn install -DskipTests
+```
+
+Will probably work. Per default, you'll find a baked `.zip`
+in `~/.m2/repository/io/snyk/plugins/artifactory-snyk-security-plugin/LOCAL-SNAPSHOT`.
+
+Edit the `.properties` file to something like:
+
+```
+snyk.api.token=<INSERT_TOKEN>
+snyk.api.organization=<INSERT_ORG_ID>
+snyk.api.url=http://host.docker.internal:8000/api/v1/
+```
+
+The latter if you want to debug against a local registry. At least if you're on OSX, you cannot probe
+against `localhost` from within a Docker container.
+
+Also, remember to activate some of the scanners depending on what you're debugging:
+
+```
+snyk.scanner.packageType.maven=true
+snyk.scanner.packageType.npm=true
+snyk.scanner.packageType.pypi=true
+```
+
+### Enable debugging JVM options
+
+```
+vim $JFROG_HOME/artifactory/var/etc/system.yaml
+``` 
+
+Add `extraJavaOpts`
+
+```
+shared:
+    ## Java 17 distribution to use
+    #javaHome: "JFROG_HOME/artifactory/app/third-party/java"
+
+    ## Extra Java options to pass to the JVM. These values add to or override the defaults.
+    #extraJavaOpts: "-Xms512m -Xmx4g"
+    extraJavaOpts: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
+```
+
+### Run the Docker image
+
+And ensure you expose debugging ports, in this case, `5005`
+
+```
+docker run -d --name artifactory -p 8888:8082 -p 8081:8081 -p 5005:5005 -v $JFROG_HOME/artifactory/var/:/var/opt/jfrog/artifactory releases-docker.jfrog.io/jfrog/artifactory-pro:latest
+```
+
+Wait until the Docker has loaded, it can take a while. Check the progress with `docker logs -f <id>`.
+
+#### Notice for M1 Macs
+
+You'll have a ton of trouble if you default to building your Docker images as `linux/amd64`. At least I had. Ensure you
+do not have a env variable like `DOCKER_DEFAULT_PLATFORM=linux/amd64` enabled when pulling and/or running the image.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.11.2</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
@@ -170,7 +170,7 @@ public class SnykPlugin {
     final SnykClient snykClient = new SnykClient(config);
 
     String org = configurationModule.getPropertyOrDefault(API_ORGANIZATION);
-    var res = snykClient.getNotificationSettings(org);
+    var res = snykClient.validateCredentials(org);
     handleResponse(res);
 
     return snykClient;

--- a/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
@@ -170,7 +170,7 @@ public class SnykPlugin {
     final SnykClient snykClient = new SnykClient(config);
 
     String org = configurationModule.getPropertyOrDefault(API_ORGANIZATION);
-    var res = snykClient.validateCredentials(org);
+    var res = snykClient.getNotificationSettings(org);
     handleResponse(res);
 
     return snykClient;

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -324,7 +324,7 @@ public class ScannerModuleTest {
 
     TestResult tr = testResultCaptor.getValue();
     assertTrue(tr.success);
-    assertEquals(0, tr.dependencyCount);
+    assertEquals(1, tr.dependencyCount);
     assertEquals(0, tr.issues.vulnerabilities.size());
     assertEquals("pip", tr.packageManager);
     assertEquals(testSetup.org, tr.organisation.id);

--- a/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
@@ -77,6 +77,7 @@ public class SnykClient {
       ))
       .withQueryParam("org", organisation)
       .withQueryParam("repository", repository)
+      .withQueryParam("topLevelOnly", "true")
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, TestResult.class);
@@ -90,6 +91,7 @@ public class SnykClient {
         URLEncoder.encode(version, UTF_8)
       ))
       .withQueryParam("org", organisation)
+      .withQueryParam("topLevelOnly", "true")
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, TestResult.class);
@@ -103,6 +105,7 @@ public class SnykClient {
         URLEncoder.encode(version, UTF_8)
       ))
       .withQueryParam("org", organisation)
+      .withQueryParam("topLevelOnly", "true")
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, TestResult.class);

--- a/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
@@ -55,7 +55,7 @@ public class SnykClient {
     httpClient = builder.build();
   }
 
-  public SnykResult<NotificationSettings> getNotificationSettings(String org) throws java.io.IOException, java.lang.InterruptedException {
+  public SnykResult<NotificationSettings> validateCredentials(String org) throws java.io.IOException, java.lang.InterruptedException {
     HttpRequest request = SnykHttpRequestBuilder.create(config)
       .withPath(String.format(
         "user/me/notification-settings/org/%s",

--- a/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.snyk.sdk.SnykConfig;
 import io.snyk.sdk.config.SSLConfiguration;
 import io.snyk.sdk.model.NotificationSettings;
@@ -115,6 +116,7 @@ public class SnykClient {
         URLEncoder.encode(version, UTF_8)
       ))
       .withQueryParam("org", organisation)
+      .withQueryParam("topLevelOnly", "true")
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, TestResult.class);

--- a/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
@@ -56,7 +56,7 @@ public class SnykClient {
     httpClient = builder.build();
   }
 
-  public SnykResult<NotificationSettings> validateCredentials(String org) throws java.io.IOException, java.lang.InterruptedException {
+  public SnykResult<NotificationSettings> getNotificationSettings(String org) throws java.io.IOException, java.lang.InterruptedException {
     HttpRequest request = SnykHttpRequestBuilder.create(config)
       .withPath(String.format(
         "user/me/notification-settings/org/%s",


### PR DESCRIPTION
Currently the `/test` endpoint of the Snyk V1 API builds full dependency graphs for each package it receives. For this plugin, this means that when you do a `pip install mlflow`, you'll wait for the entire transitive dependency line of `mlflow` to be finished before `pip` continues.

The next thing `pip` does is to download the first transitive package of `mlflow`, which gets the same treatment inside Snyk, and thus it continues, wasting large amounts of time.

We recently introduced a fix to Snyk that loosens this logic of the `/test` endpoint and allows for testing of single packages while we wait for a the longer term solution to be completed by Packages and Dependencies and the Package KB project.

### Testing

There already are pretty thorough integration tests validating the `/test` endpoint results, and I don't see unit tests trying to mock that behavior, which is probably fine. Hence no new tests have been added.

### Benchmark:

Doing `pip3 install mlflow`.

Before:
```
12.24s user 2.75s system 3% cpu 7:12.33 total
```

After:
```
12.14s user 2.60s system 34% cpu 42.320 total
```

Almost a 10x performance increase! 🏃🏻 💨 