### PR TITLE
Dropping support for Java 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v2
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v2
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11]
+        java: [17, 21]
     steps:
       - name: Fetch sources
         uses: actions/checkout@v2


### PR DESCRIPTION
BREAKING CHANGE: This change will disable the use of this plugin for Java versions 11 and older. The current LTS version is 17.