### PR TITLE
fix: [OSM-1018] update vulnerable transitive versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,14 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -169,6 +177,16 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>1.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>9.37.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.26.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Fixes: compress-compress ([CVE-2024-25710](https://www.cve.org/CVERecord?id=CVE-2024-25710)) and nimbus-jose-jwt ([CVE-2023-52428](https://www.cve.org/CVERecord?id=CVE-2023-52428)).