### PR TITLE
fix: remove topLevelOnly query for reqs

### DIFF
--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -324,7 +324,7 @@ public class ScannerModuleTest {
 
     TestResult tr = testResultCaptor.getValue();
     assertTrue(tr.success);
-    assertEquals(1, tr.dependencyCount);
+    assertEquals(0, tr.dependencyCount);
     assertEquals(0, tr.issues.vulnerabilities.size());
     assertEquals("pip", tr.packageManager);
     assertEquals(testSetup.org, tr.organisation.id);

--- a/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/api/v1/SnykClient.java
@@ -77,7 +77,6 @@ public class SnykClient {
       ))
       .withQueryParam("org", organisation)
       .withQueryParam("repository", repository)
-      .withQueryParam("topLevelOnly", "true")
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, TestResult.class);
@@ -91,7 +90,6 @@ public class SnykClient {
         URLEncoder.encode(version, UTF_8)
       ))
       .withQueryParam("org", organisation)
-      .withQueryParam("topLevelOnly", "true")
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, TestResult.class);
@@ -105,7 +103,6 @@ public class SnykClient {
         URLEncoder.encode(version, UTF_8)
       ))
       .withQueryParam("org", organisation)
-      .withQueryParam("topLevelOnly", "true")
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, TestResult.class);
@@ -119,7 +116,6 @@ public class SnykClient {
         URLEncoder.encode(version, UTF_8)
       ))
       .withQueryParam("org", organisation)
-      .withQueryParam("topLevelOnly", "true")
       .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return SnykResult.createResult(response, TestResult.class);


### PR DESCRIPTION
Deprecating the topLevelOnly query param because it will be looked to be obsolete in the underlying service. It will become the default behaviour for all PMs.