### PR TITLE
refactor: use api.snyk.io as default url

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -20,8 +20,8 @@ snyk.api.organization=
 
 # The base URL for all Snyk API endpoints.
 # Documentation: https://snyk.docs.apiary.io/#introduction/api-url
-# Default: https://snyk.io/api/v1/
-#snyk.api.url=https://snyk.io/api/v1/
+# Default: https://api.snyk.io/v1/
+#snyk.api.url=https://api.snyk.io/v1/
 
 # Path to an SSL Certificate for Snyk API in PEM format.
 #snyk.api.sslCertificatePath=

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -2,7 +2,7 @@ package io.snyk.plugins.artifactory.configuration;
 
 public enum PluginConfiguration implements Configuration {
   // general settings
-  API_URL("snyk.api.url", "https://snyk.io/api/v1/"),
+  API_URL("snyk.api.url", "https://api.snyk.io/v1/"),
   API_TOKEN("snyk.api.token", ""),
   API_ORGANIZATION("snyk.api.organization", ""),
   API_SSL_CERTIFICATE_PATH("snyk.api.sslCertificatePath", ""),

--- a/core/src/test/java/io/snyk/plugins/artifactory/configuration/PluginConfigurationTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/configuration/PluginConfigurationTest.java
@@ -19,7 +19,7 @@ class PluginConfigurationTest {
   @Test
   void checkDefaultValues() {
     assertAll("should be not empty",
-              () -> assertEquals("https://snyk.io/api/v1/", API_URL.defaultValue(), getAssertionMessage(API_URL, "default value must be 'https://snyk.io/api/v1/'")),
+              () -> assertEquals("https://api.snyk.io/v1/", API_URL.defaultValue(), getAssertionMessage(API_URL, "default value must be 'https://api.snyk.io/v1/'")),
               () -> assertEquals("false", SCANNER_BLOCK_ON_API_FAILURE.defaultValue(), getAssertionMessage(SCANNER_BLOCK_ON_API_FAILURE, "default value must be 'false'")),
               () -> assertEquals("low", SCANNER_VULNERABILITY_THRESHOLD.defaultValue(), getAssertionMessage(SCANNER_VULNERABILITY_THRESHOLD, "default value must be 'low'")),
               () -> assertEquals("low", SCANNER_LICENSE_THRESHOLD.defaultValue(), getAssertionMessage(SCANNER_LICENSE_THRESHOLD, "default value must be 'low'"))

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
@@ -41,7 +41,7 @@ public class PythonScannerTest {
     TestResult result = scanner.scan(fileLayoutInfo, repoPath);
     assertFalse(result.success);
     assertEquals(1, result.dependencyCount);
-    assertEquals(5, result.issues.vulnerabilities.size());
+    assertEquals(6, result.issues.vulnerabilities.size());
     assertEquals("pip", result.packageManager);
     assertEquals(org, result.organisation.id);
     assertEquals("https://snyk.io/vuln/pip%3Aurllib3%401.25.7", result.packageDetailsURL);

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -366,7 +366,7 @@ public class ScannerModuleTest {
     TestResult tr = testResultCaptor.getValue();
     assertFalse(tr.success);
     assertEquals(1, tr.dependencyCount);
-    assertEquals(5, tr.issues.vulnerabilities.size());
+    assertEquals(6, tr.issues.vulnerabilities.size());
     assertEquals("pip", tr.packageManager);
     assertEquals(testSetup.org, tr.organisation.id);
 

--- a/core/src/test/resources/io/snyk/plugins/artifactory/PropertyLoaderTest/valid-property-file/snykSecurityPlugin.properties
+++ b/core/src/test/resources/io/snyk/plugins/artifactory/PropertyLoaderTest/valid-property-file/snykSecurityPlugin.properties
@@ -1,4 +1,4 @@
-snyk.api.url=https://snyk.io/api/v1/
+snyk.api.url=https://api.snyk.io/v1/
 snyk.api.token=my-api-token
 snyk.api.organization=my-api-organization
 #

--- a/helm-install/install-helm.sh
+++ b/helm-install/install-helm.sh
@@ -28,7 +28,7 @@ pushd "$SCRIPT_DIR/.." || exit 1
     if [[ $SNYK_TOKEN == "" ]]; then
       $SNYK auth
     fi
-    ORG=$(curl -s -H "Authorization: token $SNYK_TOKEN" https://snyk.io/api/v1/orgs | jq -r '.orgs|first|.id')
+    ORG=$(curl -s -H "Authorization: token $SNYK_TOKEN" https://api.snyk.io/v1/orgs | jq -r '.orgs|first|.id')
 
     # monkey patching config file
     pushd plugins

--- a/snyk-sdk-tests/src/test/java/io/snyk/sdk/SnykClientTest.java
+++ b/snyk-sdk-tests/src/test/java/io/snyk/sdk/SnykClientTest.java
@@ -20,7 +20,7 @@ class SnykClientTest {
   void createSnykConfig_shouldReturnDefaultValues_ifNotDefined() {
     Config config = new Config("snyk-api-token");
 
-    assertEquals("https://snyk.io/api/v1/", config.baseUrl);
+    assertEquals("https://api.snyk.io/v1/", config.baseUrl);
     assertEquals("snyk-sdk-java", config.userAgent);
   }
 

--- a/snyk-sdk/src/main/java/io/snyk/sdk/SnykConfig.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/SnykConfig.java
@@ -42,7 +42,7 @@ public class SnykConfig {
 
   public static class Builder {
     private String token;
-    private String baseUrl = "https://snyk.io/api/v1/";
+    private String baseUrl = "https://api.snyk.io/v1/";
     private String userAgent = "snyk-sdk-java";
     private boolean trustAllCertificates = false;
     private String sslCertificatePath = "";

--- a/snyk-sdk/src/test/java/io/snyk/sdk/api/v1/SnykHttpRequestBuilderTest.java
+++ b/snyk-sdk/src/test/java/io/snyk/sdk/api/v1/SnykHttpRequestBuilderTest.java
@@ -16,7 +16,7 @@ public class SnykHttpRequestBuilderTest {
     assertEquals(SnykHttpRequestBuilder.create(configWithDefaultBaseUrl)
         .build()
         .uri().toString(),
-      "https://snyk.io/api/v1/");
+      "https://api.snyk.io/v1/");
 
     String otherBaseUrl = "https://other-host/some-prefix/";
     SnykConfig configWithDifferentBaseUrl = SnykConfig.newBuilder().setBaseUrl(otherBaseUrl).build();
@@ -34,7 +34,7 @@ public class SnykHttpRequestBuilderTest {
   void shouldOnlyIncludeNonNullQueryParameters() {
     SnykConfig config = SnykConfig.withDefaults();
 
-    assertEquals("https://snyk.io/api/v1/some/endpoint?org=abc123",
+    assertEquals("https://api.snyk.io/v1/some/endpoint?org=abc123",
       SnykHttpRequestBuilder.create(config)
         .withPath("some/endpoint")
         .withQueryParam("org", "abc123")
@@ -48,7 +48,7 @@ public class SnykHttpRequestBuilderTest {
   @Test
   void shouldOnlyIncludePresentQueryParameters() {
     SnykConfig config = SnykConfig.withDefaults();
-    assertEquals("https://snyk.io/api/v1/some/endpoint?org=abc123",
+    assertEquals("https://api.snyk.io/v1/some/endpoint?org=abc123",
       SnykHttpRequestBuilder.create(config)
         .withPath("some/endpoint")
         .withQueryParam("org", Optional.of("abc123"))
@@ -62,7 +62,7 @@ public class SnykHttpRequestBuilderTest {
   @Test
   void shouldIncludeMultipleQueryParameters() {
     SnykConfig config = SnykConfig.withDefaults();
-    assertEquals("https://snyk.io/api/v1/some/endpoint?org=abc123&foo=bar",
+    assertEquals("https://api.snyk.io/v1/some/endpoint?org=abc123&foo=bar",
       SnykHttpRequestBuilder.create(config)
         .withPath("some/endpoint")
         .withQueryParam("org", "abc123")


### PR DESCRIPTION
`snyk.io/api` is the legacy and deprecated way to access Snyk APIs. Let's default to `api.snyk.io` instead.