### PR TITLE
chore: extract ecosystem enum [OSM-2231]

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/Ecosystem.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/Ecosystem.java
@@ -1,0 +1,39 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import io.snyk.plugins.artifactory.configuration.PluginConfiguration;
+
+import java.util.Optional;
+
+public enum Ecosystem {
+
+  MAVEN(PluginConfiguration.SCANNER_PACKAGE_TYPE_MAVEN),
+  NPM(PluginConfiguration.SCANNER_PACKAGE_TYPE_NPM),
+  PYPI(PluginConfiguration.SCANNER_PACKAGE_TYPE_PYPI),
+  ;
+
+  private final PluginConfiguration configProperty;
+
+  Ecosystem(PluginConfiguration configProperty) {
+    this.configProperty = configProperty;
+  }
+
+  public PluginConfiguration getConfigProperty() {
+    return configProperty;
+  }
+
+  static Optional<Ecosystem> fromPackagePath(String path) {
+    if (path.endsWith(".jar")) {
+      return Optional.of(MAVEN);
+    }
+
+    if (path.endsWith(".tgz")) {
+      return Optional.of(NPM);
+    }
+
+    if (path.endsWith(".whl") || path.endsWith(".tar.gz") || path.endsWith(".zip") || path.endsWith(".egg")) {
+      return Optional.of(PYPI);
+    }
+
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/EcosystemTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/EcosystemTest.java
@@ -1,0 +1,19 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EcosystemTest {
+
+  @Test
+  void testGetScannerForPackageType() {
+    assertEquals(Ecosystem.MAVEN, Ecosystem.fromPackagePath("myArtifact.jar").orElse(null));
+    assertEquals(Ecosystem.NPM, Ecosystem.fromPackagePath("myArtifact.tgz").orElse(null));
+    assertEquals(Ecosystem.PYPI, Ecosystem.fromPackagePath("myArtifact.whl").orElse(null));
+    assertEquals(Ecosystem.PYPI, Ecosystem.fromPackagePath("myArtifact.tar.gz").orElse(null));
+    assertEquals(Ecosystem.PYPI, Ecosystem.fromPackagePath("myArtifact.zip").orElse(null));
+    assertEquals(Ecosystem.PYPI, Ecosystem.fromPackagePath("myArtifact.egg").orElse(null));
+    assertNull(Ecosystem.fromPackagePath("file.txt").orElse(null));
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -30,29 +30,6 @@ import static org.mockito.Mockito.*;
 public class ScannerModuleTest {
 
   @Test
-  void testGetScannerForPackageType() {
-    Properties properties = new Properties();
-    properties.put(SCANNER_PACKAGE_TYPE_MAVEN.propertyKey(), "true");
-    properties.put(SCANNER_PACKAGE_TYPE_NPM.propertyKey(), "true");
-    properties.put(SCANNER_PACKAGE_TYPE_PYPI.propertyKey(), "true");
-
-    ConfigurationModule configurationModule = new ConfigurationModule(properties);
-
-    ScannerModule sm = new ScannerModule(
-      configurationModule,
-      mock(Repositories.class),
-      mock(SnykClient.class));
-
-    assertEquals(MavenScanner.class, sm.getScannerForPackageType("myArtifact.jar").getClass());
-    assertEquals(NpmScanner.class, sm.getScannerForPackageType("myArtifact.tgz").getClass());
-    assertEquals(PythonScanner.class, sm.getScannerForPackageType("myArtifact.whl").getClass());
-    assertEquals(PythonScanner.class, sm.getScannerForPackageType("myArtifact.tar.gz").getClass());
-    assertEquals(PythonScanner.class, sm.getScannerForPackageType("myArtifact.zip").getClass());
-    assertEquals(PythonScanner.class, sm.getScannerForPackageType("myArtifact.egg").getClass());
-    assertThrows(CannotScanException.class, () -> sm.getScannerForPackageType("unknown"));
-  }
-
-  @Test
   void testGetScannerForPackageType_cannotScanPathsWithDisabledScanners() {
     Properties properties = new Properties();
     properties.put(SCANNER_PACKAGE_TYPE_MAVEN.propertyKey(), "false");


### PR DESCRIPTION
Adding new ecosystem support in small steps because the diff for [the original work](https://github.com/gwnlng/artifactory-snyk-security-plugin/tree/feat/cocoapods-nuget2) is too massive. First baby step = introducing the Ecosystem enum and extracting the file matching logic to it.