### PR TITLE
chore: introduce artefact model [OSM-2240]

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/model/Ignores.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/Ignores.java
@@ -1,0 +1,52 @@
+package io.snyk.plugins.artifactory.model;
+
+import io.snyk.plugins.artifactory.configuration.ArtifactProperty;
+import org.artifactory.repo.RepoPath;
+import org.artifactory.repo.Repositories;
+
+import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
+import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
+
+public class Ignores {
+
+  private final boolean ignoreVulnIssues;
+
+  private final boolean ignoreLicenseIssues;
+
+  public Ignores() {
+    this(false, false);
+  }
+
+  private Ignores(boolean ignoreVulnIssues, boolean ignoreLicenseIssues) {
+    this.ignoreVulnIssues = ignoreVulnIssues;
+    this.ignoreLicenseIssues = ignoreLicenseIssues;
+  }
+
+  public boolean shouldIgnoreVulnIssues() {
+    return ignoreVulnIssues;
+  }
+
+  public Ignores withIgnoreVulnIssues(boolean ignoreVulnIssues) {
+    return new Ignores(ignoreVulnIssues, ignoreLicenseIssues);
+  }
+
+  public boolean shouldIgnoreLicenseIssues() {
+    return ignoreLicenseIssues;
+  }
+
+  public Ignores withIgnoreLicenseIssues(boolean ignoreLicenseIssues) {
+    return new Ignores(ignoreVulnIssues, ignoreLicenseIssues);
+  }
+
+  public static Ignores fromProperties(Repositories repositories, RepoPath repoPath) {
+    boolean ignoreVulnIssues = readIgnoreFlag(repositories, repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD);
+    boolean ignoreLicenseIssues = readIgnoreFlag(repositories, repoPath, ISSUE_LICENSES_FORCE_DOWNLOAD);
+    return new Ignores(ignoreVulnIssues, ignoreLicenseIssues);
+  }
+
+  private static boolean readIgnoreFlag(Repositories repositories, RepoPath repoPath, ArtifactProperty property) {
+    final String vulnerabilitiesForceDownloadProperty = property.propertyKey();
+    final String vulnerabilitiesForceDownload = repositories.getProperty(repoPath, vulnerabilitiesForceDownloadProperty);
+    return "true".equalsIgnoreCase(vulnerabilitiesForceDownload);
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/IssueSummary.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/IssueSummary.java
@@ -1,0 +1,42 @@
+package io.snyk.plugins.artifactory.model;
+
+import io.snyk.sdk.model.Issue;
+import io.snyk.sdk.model.Severity;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class IssueSummary {
+
+  private final Map<Severity, Integer> countBySeverity;
+
+  private IssueSummary(Map<Severity, Integer> countBySeverity) {
+    this.countBySeverity = countBySeverity;
+  }
+
+  public static IssueSummary from(List<? extends Issue> issues) {
+    return IssueSummary.from(issues.stream().map(i -> i.severity));
+  }
+
+  public static IssueSummary from(Stream<Severity> severities) {
+    return new IssueSummary(severities.collect(Collectors.toMap(s -> s, s -> 1, Integer::sum)));
+  }
+
+  public int getCountAtOrAbove(Severity severity) {
+    int total = 0;
+    for (Severity value : Arrays.asList(Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW)) {
+      total += getBySeverity(value);
+      if (value == severity) {
+        return total;
+      }
+    }
+    return total;
+  }
+
+  private int getBySeverity(Severity severity) {
+    return countBySeverity.getOrDefault(severity, 0);
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
@@ -1,0 +1,32 @@
+package io.snyk.plugins.artifactory.model;
+
+public class MonitoredArtifact {
+
+  private final String path;
+  private final IssueSummary vulnSummary;
+  private final IssueSummary licenseSummary;
+  private final Ignores ignores;
+
+  public MonitoredArtifact(String path, IssueSummary vulnSummary, IssueSummary licenseSummary, Ignores ignores) {
+    this.path = path;
+    this.vulnSummary = vulnSummary;
+    this.licenseSummary = licenseSummary;
+    this.ignores = ignores;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public IssueSummary getVulnSummary() {
+    return vulnSummary;
+  }
+
+  public IssueSummary getLicenseSummary() {
+    return licenseSummary;
+  }
+
+  public Ignores getIgnores() {
+    return ignores;
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/ValidationSettings.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/ValidationSettings.java
@@ -1,0 +1,45 @@
+package io.snyk.plugins.artifactory.model;
+
+import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
+import io.snyk.sdk.model.Severity;
+
+import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_LICENSE_THRESHOLD;
+import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_VULNERABILITY_THRESHOLD;
+
+public class ValidationSettings {
+
+  private final Severity vulnSeverityThreshold;
+
+  private final Severity licenseSeverityThreshold;
+
+  public ValidationSettings() {
+    this(Severity.HIGH, Severity.HIGH);
+  }
+
+  private ValidationSettings(Severity vulnSeverityThreshold, Severity licenseSeverityThreshold) {
+    this.vulnSeverityThreshold = vulnSeverityThreshold;
+    this.licenseSeverityThreshold = licenseSeverityThreshold;
+  }
+
+  public ValidationSettings withVulnSeverityThreshold(Severity threshold) {
+    return new ValidationSettings(threshold, licenseSeverityThreshold);
+  }
+
+  public ValidationSettings withLicenseSeverityThreshold(Severity threshold) {
+    return new ValidationSettings(vulnSeverityThreshold, threshold);
+  }
+
+  public Severity getVulnSeverityThreshold() {
+    return vulnSeverityThreshold;
+  }
+
+  public Severity getLicenseSeverityThreshold() {
+    return licenseSeverityThreshold;
+  }
+
+  public static ValidationSettings from(ConfigurationModule config) {
+    return new ValidationSettings()
+      .withVulnSeverityThreshold(Severity.of(config.getPropertyOrDefault(SCANNER_VULNERABILITY_THRESHOLD)))
+      .withLicenseSeverityThreshold(Severity.of(config.getPropertyOrDefault(SCANNER_LICENSE_THRESHOLD)));
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
@@ -1,110 +1,62 @@
 package io.snyk.plugins.artifactory.scanner;
 
-import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
-import io.snyk.plugins.artifactory.configuration.PluginConfiguration;
+import io.snyk.plugins.artifactory.model.IssueSummary;
+import io.snyk.plugins.artifactory.model.MonitoredArtifact;
+import io.snyk.plugins.artifactory.model.ValidationSettings;
 import io.snyk.sdk.model.Severity;
-import io.snyk.sdk.model.TestResult;
 import org.artifactory.exception.CancelException;
-import org.artifactory.repo.RepoPath;
-import org.artifactory.repo.Repositories;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
 import static java.lang.String.format;
 
 public class PackageValidator {
 
   private static final Logger LOG = LoggerFactory.getLogger(PackageValidator.class);
 
-  private final ConfigurationModule configurationModule;
-  private final Repositories repositories;
+  private final ValidationSettings settings;
 
-  public PackageValidator(ConfigurationModule configurationModule, Repositories repositories) {
-    this.configurationModule = configurationModule;
-    this.repositories = repositories;
+  public PackageValidator(ValidationSettings settings) {
+    this.settings = settings;
   }
 
-  public void validate(TestResult testResult, RepoPath repoPath) {
-    validateVulnerabilityIssues(testResult, repoPath);
-    validateLicenseIssues(testResult, repoPath);
+  public void validate(MonitoredArtifact artifact) {
+    validateVulnerabilityIssues(artifact);
+    validateLicenseIssues(artifact);
   }
 
-  private void validateVulnerabilityIssues(TestResult testResult, RepoPath repoPath) {
-    final String vulnerabilitiesForceDownloadProperty = ISSUE_VULNERABILITIES_FORCE_DOWNLOAD.propertyKey();
-    final String vulnerabilitiesForceDownload = repositories.getProperty(repoPath, vulnerabilitiesForceDownloadProperty);
-    final boolean forceDownload = "true".equalsIgnoreCase(vulnerabilitiesForceDownload);
-    if (forceDownload) {
-      LOG.debug("Allowing download. Artifact Property \"{}\" is \"true\". {}", vulnerabilitiesForceDownloadProperty, repoPath);
+  private void validateVulnerabilityIssues(MonitoredArtifact artifact) {
+    validateIssues(
+      artifact.getVulnSummary(),
+      settings.getVulnSeverityThreshold(),
+      artifact.getIgnores().shouldIgnoreVulnIssues(),
+      format("VULNERABILITIES, %s", artifact.getPath())
+    );
+  }
+
+  private void validateLicenseIssues(MonitoredArtifact artifact) {
+    validateIssues(
+      artifact.getLicenseSummary(),
+      settings.getLicenseSeverityThreshold(),
+      artifact.getIgnores().shouldIgnoreLicenseIssues(),
+      format("LICENSES, %s", artifact.getPath())
+    );
+  }
+
+  private void validateIssues(IssueSummary summary, Severity threshold, boolean ignoreIssues, String logContext) {
+    int countAboveThreshold = summary.getCountAtOrAbove(threshold);
+    if (countAboveThreshold == 0) {
+      LOG.debug("No issues with severity {} or higher: {}", threshold, logContext);
       return;
     }
 
-    Severity vulnerabilityThreshold = Severity.of(configurationModule.getPropertyOrDefault(PluginConfiguration.SCANNER_VULNERABILITY_THRESHOLD));
-    if (vulnerabilityThreshold == Severity.LOW) {
-      if (!testResult.issues.vulnerabilities.isEmpty()) {
-        LOG.debug("Found vulnerabilities in {} returning 403", repoPath);
-        throw new CancelException(format("Artifact has vulnerabilities. %s", repoPath), 403);
-      }
-    } else if (vulnerabilityThreshold == Severity.MEDIUM) {
-      long count = testResult.issues.vulnerabilities.stream()
-        .filter(vulnerability -> vulnerability.severity == Severity.MEDIUM || vulnerability.severity == Severity.HIGH || vulnerability.severity == Severity.CRITICAL)
-        .count();
-      if (count > 0) {
-        LOG.debug("Found {} vulnerabilities in {} returning 403", count, repoPath);
-        throw new CancelException(format("Artifact has vulnerabilities with medium, high or critical severity. %s", repoPath), 403);
-      }
-    } else if (vulnerabilityThreshold == Severity.HIGH) {
-      long count = testResult.issues.vulnerabilities.stream()
-        .filter(vulnerability -> vulnerability.severity == Severity.HIGH || vulnerability.severity == Severity.CRITICAL)
-        .count();
-      if (count > 0) {
-        LOG.debug("Found {}, vulnerabilities in {} returning 403", count, repoPath);
-        throw new CancelException(format("Artifact has vulnerabilities with high or critical severity. %s", repoPath), 403);
-      }
-    } else if (vulnerabilityThreshold == Severity.CRITICAL) {
-      long count = testResult.issues.vulnerabilities.stream()
-        .filter(vulnerability -> vulnerability.severity == Severity.CRITICAL)
-        .count();
-      if (count > 0) {
-        LOG.debug("Found {} vulnerabilities in {} returning 403", count, repoPath);
-        throw new CancelException(format("Artifact has vulnerabilities with critical severity. %s", repoPath), 403);
-      }
-    }
-  }
-
-  private void validateLicenseIssues(TestResult testResult, RepoPath repoPath) {
-    final String licensesForceDownloadProperty = ISSUE_LICENSES_FORCE_DOWNLOAD.propertyKey();
-    final String licensesForceDownload = repositories.getProperty(repoPath, licensesForceDownloadProperty);
-    final boolean forceDownload = "true".equalsIgnoreCase(licensesForceDownload);
-    if (forceDownload) {
-      LOG.debug("Allowing download. Artifact Property \"{}\" is \"true\". {}", repoPath, licensesForceDownloadProperty);
+    if (ignoreIssues) {
+      LOG.debug("Allowing download because issues are ignored: {}", logContext);
       return;
     }
 
-    Severity licensesThreshold = Severity.of(configurationModule.getPropertyOrDefault(PluginConfiguration.SCANNER_LICENSE_THRESHOLD));
-    if (licensesThreshold == Severity.LOW) {
-      if (!testResult.issues.licenses.isEmpty()) {
-        LOG.debug("Found license issues in {} returning 403", repoPath);
-        throw new CancelException(format("Artifact has license issues. %s", repoPath), 403);
-      }
-    } else if (licensesThreshold == Severity.MEDIUM) {
-      long count = testResult.issues.licenses.stream()
-        .filter(vulnerability -> vulnerability.severity == Severity.MEDIUM || vulnerability.severity == Severity.HIGH)
-        .count();
-      if (count > 0) {
-        LOG.debug("Found {} license issues in {} returning 403", count, repoPath);
-        throw new CancelException(format("Artifact has license issues with medium or high severity. %s", repoPath), 403);
-      }
-    } else if (licensesThreshold == Severity.HIGH) {
-      long count = testResult.issues.licenses.stream()
-        .filter(vulnerability -> vulnerability.severity == Severity.HIGH)
-        .count();
-      if (count > 0) {
-        LOG.debug("Found {} license issues in {} returning 403", count, repoPath);
-        throw new CancelException(format("Artifact has license issues with high severity. %s", repoPath), 403);
-      }
-    }
+    LOG.debug("Package has issues with severity {} or higher: {}", threshold, logContext);
+    throw new CancelException(format("Artifact has license issues with severity %s or higher: %s", threshold, logContext), 403);
   }
 
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/model/IssueSummaryTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/model/IssueSummaryTest.java
@@ -1,0 +1,26 @@
+package io.snyk.plugins.artifactory.model;
+
+import io.snyk.sdk.model.Severity;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IssueSummaryTest {
+
+  @Test
+  void getCountAtOrAbove() {
+    IssueSummary summary = IssueSummary.from(Stream.of(
+      Severity.LOW, Severity.LOW, Severity.LOW, Severity.LOW,
+      Severity.MEDIUM, Severity.MEDIUM, Severity.MEDIUM,
+      Severity.HIGH, Severity.HIGH,
+      Severity.CRITICAL
+    ));
+
+    assertEquals(1, summary.getCountAtOrAbove(Severity.CRITICAL));
+    assertEquals(3, summary.getCountAtOrAbove(Severity.HIGH));
+    assertEquals(6, summary.getCountAtOrAbove(Severity.MEDIUM));
+    assertEquals(10, summary.getCountAtOrAbove(Severity.LOW));
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/PackageValidatorTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/PackageValidatorTest.java
@@ -1,121 +1,92 @@
 package io.snyk.plugins.artifactory.scanner;
 
-import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
-import io.snyk.plugins.artifactory.configuration.PluginConfiguration;
-import io.snyk.sdk.model.*;
+import io.snyk.plugins.artifactory.model.Ignores;
+import io.snyk.plugins.artifactory.model.IssueSummary;
+import io.snyk.plugins.artifactory.model.MonitoredArtifact;
+import io.snyk.plugins.artifactory.model.ValidationSettings;
+import io.snyk.sdk.model.Severity;
 import org.artifactory.exception.CancelException;
-import org.artifactory.repo.RepoPath;
-import org.artifactory.repo.Repositories;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Properties;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class PackageValidatorTest {
 
   @Test
   void validate_severityBelowThreshold_allowed() {
-    Repositories repositories = mock(Repositories.class);
-    RepoPath repoPath = mock(RepoPath.class);
+    ValidationSettings settings = new ValidationSettings()
+      .withVulnSeverityThreshold(Severity.MEDIUM)
+      .withLicenseSeverityThreshold(Severity.CRITICAL);
+    PackageValidator validator = new PackageValidator(settings);
+    MonitoredArtifact artifact = new MonitoredArtifact("",
+      IssueSummary.from(Stream.of(Severity.LOW)),
+      IssueSummary.from(Stream.of(Severity.MEDIUM)),
+      new Ignores()
+    );
 
-    ConfigurationModule configurationModule = pluginConfig(Severity.MEDIUM, Severity.CRITICAL);
-
-    PackageValidator validator = new PackageValidator(configurationModule, repositories);
-    TestResult testResult = getTestResult(List.of(Severity.LOW), List.of(Severity.MEDIUM));
-
-    assertDoesNotThrow(() -> validator.validate(testResult, repoPath));
+    assertDoesNotThrow(() -> validator.validate(artifact));
   }
 
   @Test
   void validate_vulnIssueAboveThreshold_forbidden() {
-    Repositories repositories = mock(Repositories.class);
-    RepoPath repoPath = mock(RepoPath.class);
+    ValidationSettings settings = new ValidationSettings()
+      .withVulnSeverityThreshold(Severity.HIGH)
+      .withLicenseSeverityThreshold(Severity.LOW);
+    PackageValidator validator = new PackageValidator(settings);
+    MonitoredArtifact artifact = new MonitoredArtifact("",
+      IssueSummary.from(Stream.of(Severity.HIGH)),
+      IssueSummary.from(Stream.empty()),
+      new Ignores()
+    );
 
-    ConfigurationModule configurationModule = pluginConfig(Severity.HIGH, Severity.LOW);
-
-    PackageValidator validator = new PackageValidator(configurationModule, repositories);
-    TestResult testResult = getTestResult(List.of(Severity.HIGH), List.of());
-
-    assertThrows(CancelException.class, () -> validator.validate(testResult, repoPath));
+    assertThrows(CancelException.class, () -> validator.validate(artifact));
   }
 
   @Test
-  void validate_vulnForceDownload_allowed() {
-    Repositories repositories = mock(Repositories.class);
-    RepoPath repoPath = mock(RepoPath.class);
+  void validate_vulnIssuesIgnored_allowed() {
+    ValidationSettings settings = new ValidationSettings()
+      .withVulnSeverityThreshold(Severity.HIGH)
+      .withLicenseSeverityThreshold(Severity.LOW);
+    PackageValidator validator = new PackageValidator(settings);
+    MonitoredArtifact artifact = new MonitoredArtifact("",
+      IssueSummary.from(Stream.of(Severity.HIGH)),
+      IssueSummary.from(Stream.empty()),
+      new Ignores().withIgnoreVulnIssues(true)
+    );
 
-    when(repositories.getProperty(repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD.propertyKey())).thenReturn("true");
-
-    ConfigurationModule configurationModule = pluginConfig(Severity.HIGH, Severity.LOW);
-
-    PackageValidator validator = new PackageValidator(configurationModule, repositories);
-    TestResult testResult = getTestResult(List.of(Severity.HIGH), List.of());
-
-    assertDoesNotThrow(() -> validator.validate(testResult, repoPath));
+    assertDoesNotThrow(() -> validator.validate(artifact));
   }
 
   @Test
   void validate_licenseIssueAboveThreshold_forbidden() {
-    Repositories repositories = mock(Repositories.class);
-    RepoPath repoPath = mock(RepoPath.class);
+    ValidationSettings settings = new ValidationSettings()
+      .withVulnSeverityThreshold(Severity.LOW)
+      .withLicenseSeverityThreshold(Severity.MEDIUM);
+    PackageValidator validator = new PackageValidator(settings);
+    MonitoredArtifact artifact = new MonitoredArtifact("",
+      IssueSummary.from(Stream.empty()),
+      IssueSummary.from(Stream.of(Severity.MEDIUM)),
+      new Ignores()
+    );
 
-    ConfigurationModule configurationModule = pluginConfig(Severity.LOW, Severity.MEDIUM);
-
-    PackageValidator validator = new PackageValidator(configurationModule, repositories);
-    TestResult testResult = getTestResult(List.of(), List.of(Severity.MEDIUM));
-
-    assertThrows(CancelException.class, () -> validator.validate(testResult, repoPath));
+    assertThrows(CancelException.class, () -> validator.validate(artifact));
   }
 
   @Test
-  void validate_licenseForceDownload_allowed() {
-    Repositories repositories = mock(Repositories.class);
-    RepoPath repoPath = mock(RepoPath.class);
+  void validate_licenseIssuesIgnored_allowed() {
+    ValidationSettings settings = new ValidationSettings()
+      .withVulnSeverityThreshold(Severity.LOW)
+      .withLicenseSeverityThreshold(Severity.MEDIUM);
+    PackageValidator validator = new PackageValidator(settings);
+    MonitoredArtifact artifact = new MonitoredArtifact("",
+      IssueSummary.from(Stream.empty()),
+      IssueSummary.from(Stream.of(Severity.MEDIUM)),
+      new Ignores().withIgnoreLicenseIssues(true)
+    );
 
-    when(repositories.getProperty(repoPath, ISSUE_LICENSES_FORCE_DOWNLOAD.propertyKey())).thenReturn("true");
-
-    ConfigurationModule configurationModule = pluginConfig(Severity.LOW, Severity.MEDIUM);
-
-    PackageValidator validator = new PackageValidator(configurationModule, repositories);
-    TestResult testResult = getTestResult(List.of(), List.of(Severity.MEDIUM));
-
-    assertDoesNotThrow(() -> validator.validate(testResult, repoPath));
+    assertDoesNotThrow(() -> validator.validate(artifact));
   }
-
-  private static @NotNull ConfigurationModule pluginConfig(Severity vulnThreshold, Severity licenseThreshold) {
-    Properties properties = new Properties();
-    properties.setProperty(PluginConfiguration.SCANNER_VULNERABILITY_THRESHOLD.propertyKey(), vulnThreshold.getSeverityLevel());
-    properties.setProperty(PluginConfiguration.SCANNER_LICENSE_THRESHOLD.propertyKey(), licenseThreshold.getSeverityLevel());
-    return new ConfigurationModule(properties);
-  }
-
-  private static @NotNull TestResult getTestResult(List<Severity> vulnSeverities, List<Severity> licenseSeverities) {
-    TestResult testResult = new TestResult();
-
-    testResult.issues = new Issues();
-
-    testResult.issues.vulnerabilities = vulnSeverities.stream().map(severity -> {
-      Vulnerability vuln = new Vulnerability();
-      vuln.severity = severity;
-      return vuln;
-    }).collect(Collectors.toList());
-
-    testResult.issues.licenses = licenseSeverities.stream().map(severity -> {
-      Issue issue = new Vulnerability();
-      issue.severity = severity;
-      return issue;
-    }).collect(Collectors.toList());
-    return testResult;
-  }
-
-
 }


### PR DESCRIPTION
In order to let the validation run against cached artefact metadata rather than a full test result, introducing a model representing issue summary.

For the time being, the model is always created from a test result but in a follow-up PR we'll also support deriving it from cached data. This way we'll be able to avoid making an unnecessary Snyk Test request when there is fresh vuln information already.