### PR TITLE
chore: write properties based on artefact [OSM-2240]

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/model/IssueSummary.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/IssueSummary.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
+
 public class IssueSummary {
 
   private final Map<Severity, Integer> countBySeverity;
@@ -28,7 +30,7 @@ public class IssueSummary {
   public int getCountAtOrAbove(Severity severity) {
     int total = 0;
     for (Severity value : Arrays.asList(Severity.CRITICAL, Severity.HIGH, Severity.MEDIUM, Severity.LOW)) {
-      total += getBySeverity(value);
+      total += getCountBySeverity(value);
       if (value == severity) {
         return total;
       }
@@ -36,7 +38,21 @@ public class IssueSummary {
     return total;
   }
 
-  private int getBySeverity(Severity severity) {
+  private int getCountBySeverity(Severity severity) {
     return countBySeverity.getOrDefault(severity, 0);
+  }
+
+  public int getTotalCount() {
+    return getCountAtOrAbove(Severity.LOW);
+  }
+
+  @Override
+  public String toString() {
+    return format("%d critical, %d high, %d medium, %d low",
+            getCountBySeverity(Severity.CRITICAL),
+            getCountBySeverity(Severity.HIGH),
+            getCountBySeverity(Severity.MEDIUM),
+            getCountBySeverity(Severity.LOW)
+    );
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
@@ -1,17 +1,21 @@
 package io.snyk.plugins.artifactory.model;
 
+import java.net.URI;
+
 public class MonitoredArtifact {
 
   private final String path;
   private final IssueSummary vulnSummary;
   private final IssueSummary licenseSummary;
   private final Ignores ignores;
+  private final URI detailsUrl;
 
-  public MonitoredArtifact(String path, IssueSummary vulnSummary, IssueSummary licenseSummary, Ignores ignores) {
+  public MonitoredArtifact(String path, IssueSummary vulnSummary, IssueSummary licenseSummary, Ignores ignores, URI detailsUrl) {
     this.path = path;
     this.vulnSummary = vulnSummary;
     this.licenseSummary = licenseSummary;
     this.ignores = ignores;
+    this.detailsUrl = detailsUrl;
   }
 
   public String getPath() {
@@ -28,5 +32,9 @@ public class MonitoredArtifact {
 
   public Ignores getIgnores() {
     return ignores;
+  }
+
+  public URI getDetailsUrl() {
+    return detailsUrl;
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/model/IssueSummaryTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/model/IssueSummaryTest.java
@@ -1,6 +1,7 @@
 package io.snyk.plugins.artifactory.model;
 
 import io.snyk.sdk.model.Severity;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.Stream;
@@ -9,18 +10,33 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class IssueSummaryTest {
 
-  @Test
-  void getCountAtOrAbove() {
-    IssueSummary summary = IssueSummary.from(Stream.of(
+    IssueSummary summary;
+
+  @BeforeEach
+  void setUp() {
+    summary = IssueSummary.from(Stream.of(
       Severity.LOW, Severity.LOW, Severity.LOW, Severity.LOW,
       Severity.MEDIUM, Severity.MEDIUM, Severity.MEDIUM,
       Severity.HIGH, Severity.HIGH,
       Severity.CRITICAL
     ));
+  }
 
+  @Test
+  void getCountAtOrAbove() {
     assertEquals(1, summary.getCountAtOrAbove(Severity.CRITICAL));
     assertEquals(3, summary.getCountAtOrAbove(Severity.HIGH));
     assertEquals(6, summary.getCountAtOrAbove(Severity.MEDIUM));
     assertEquals(10, summary.getCountAtOrAbove(Severity.LOW));
+  }
+
+  @Test
+  void getTotalCount() {
+    assertEquals(10, summary.getTotalCount());
+  }
+
+  @Test
+  void toString_withAllSeverities() {
+    assertEquals("1 critical, 2 high, 3 medium, 4 low", summary.toString());
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/PackageValidatorTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/PackageValidatorTest.java
@@ -8,6 +8,7 @@ import io.snyk.sdk.model.Severity;
 import org.artifactory.exception.CancelException;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -24,7 +25,8 @@ class PackageValidatorTest {
     MonitoredArtifact artifact = new MonitoredArtifact("",
       IssueSummary.from(Stream.of(Severity.LOW)),
       IssueSummary.from(Stream.of(Severity.MEDIUM)),
-      new Ignores()
+      new Ignores(),
+      URI.create("https://snyk.io/package/version")
     );
 
     assertDoesNotThrow(() -> validator.validate(artifact));
@@ -39,7 +41,8 @@ class PackageValidatorTest {
     MonitoredArtifact artifact = new MonitoredArtifact("",
       IssueSummary.from(Stream.of(Severity.HIGH)),
       IssueSummary.from(Stream.empty()),
-      new Ignores()
+      new Ignores(),
+      URI.create("https://snyk.io/package/version")
     );
 
     assertThrows(CancelException.class, () -> validator.validate(artifact));
@@ -54,7 +57,8 @@ class PackageValidatorTest {
     MonitoredArtifact artifact = new MonitoredArtifact("",
       IssueSummary.from(Stream.of(Severity.HIGH)),
       IssueSummary.from(Stream.empty()),
-      new Ignores().withIgnoreVulnIssues(true)
+      new Ignores().withIgnoreVulnIssues(true),
+      URI.create("https://snyk.io/package/version")
     );
 
     assertDoesNotThrow(() -> validator.validate(artifact));
@@ -69,7 +73,8 @@ class PackageValidatorTest {
     MonitoredArtifact artifact = new MonitoredArtifact("",
       IssueSummary.from(Stream.empty()),
       IssueSummary.from(Stream.of(Severity.MEDIUM)),
-      new Ignores()
+      new Ignores(),
+      URI.create("https://snyk.io/package/version")
     );
 
     assertThrows(CancelException.class, () -> validator.validate(artifact));
@@ -84,7 +89,8 @@ class PackageValidatorTest {
     MonitoredArtifact artifact = new MonitoredArtifact("",
       IssueSummary.from(Stream.empty()),
       IssueSummary.from(Stream.of(Severity.MEDIUM)),
-      new Ignores().withIgnoreLicenseIssues(true)
+      new Ignores().withIgnoreLicenseIssues(true),
+      URI.create("https://snyk.io/package/version")
     );
 
     assertDoesNotThrow(() -> validator.validate(artifact));

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -3,10 +3,10 @@ package io.snyk.plugins.artifactory.scanner;
 import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
 import io.snyk.plugins.artifactory.exception.CannotScanException;
 import io.snyk.plugins.artifactory.exception.SnykAPIFailureException;
+import io.snyk.plugins.artifactory.model.MonitoredArtifact;
 import io.snyk.plugins.artifactory.util.SnykConfigForTests;
 import io.snyk.sdk.SnykConfig;
 import io.snyk.sdk.api.v1.SnykClient;
-import io.snyk.sdk.model.TestResult;
 import org.artifactory.exception.CancelException;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
@@ -133,19 +133,15 @@ public class ScannerModuleTest {
 
     spyScanner.scanArtifact(repoPath);
 
-    ArgumentCaptor<TestResult> testResultCaptor = ArgumentCaptor.forClass(TestResult.class);
+    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
 
     verify(spyScanner, times(1)).updateProperties(
       eq(repoPath),
       testResultCaptor.capture()
     );
 
-    TestResult tr = testResultCaptor.getValue();
-    assertTrue(tr.success);
-    assertEquals(1, tr.dependencyCount);
-    assertEquals(0, tr.issues.vulnerabilities.size());
-    assertEquals("npm", tr.packageManager);
-    assertEquals(testSetup.org, tr.organisation.id);
+    MonitoredArtifact result = testResultCaptor.getValue();
+    assertEquals(0, result.getVulnSummary().getTotalCount());
   }
 
   @Test
@@ -164,19 +160,15 @@ public class ScannerModuleTest {
       spyScanner.scanArtifact(repoPath);
     });
 
-    ArgumentCaptor<TestResult> testResultCaptor = ArgumentCaptor.forClass(TestResult.class);
+    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
 
     verify(spyScanner, times(1)).updateProperties(
       eq(repoPath),
       testResultCaptor.capture()
     );
 
-    TestResult tr = testResultCaptor.getValue();
-    assertFalse(tr.success);
-    assertEquals(1, tr.dependencyCount);
-    assertTrue(tr.issues.vulnerabilities.size() > 0);
-    assertEquals("npm", tr.packageManager);
-    assertEquals(testSetup.org, tr.organisation.id);
+    MonitoredArtifact result = testResultCaptor.getValue();
+    assertTrue(result.getVulnSummary().getTotalCount() > 0);
   }
 
   @Test
@@ -193,19 +185,15 @@ public class ScannerModuleTest {
 
     spyScanner.scanArtifact(repoPath);
 
-    ArgumentCaptor<TestResult> testResultCaptor = ArgumentCaptor.forClass(TestResult.class);
+    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
 
     verify(spyScanner, times(1)).updateProperties(
       eq(repoPath),
       testResultCaptor.capture()
     );
 
-    TestResult tr = testResultCaptor.getValue();
-    assertTrue(tr.success);
-    assertEquals(1, tr.dependencyCount);
-    assertEquals(0, tr.issues.vulnerabilities.size());
-    assertEquals("maven", tr.packageManager);
-    assertEquals(testSetup.org, tr.organisation.id);
+    MonitoredArtifact result = testResultCaptor.getValue();
+    assertEquals(0, result.getVulnSummary().getTotalCount());
   }
 
   @Test
@@ -224,19 +212,15 @@ public class ScannerModuleTest {
       spyScanner.scanArtifact(repoPath);
     });
 
-    ArgumentCaptor<TestResult> testResultCaptor = ArgumentCaptor.forClass(TestResult.class);
+    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
 
     verify(spyScanner, times(1)).updateProperties(
       eq(repoPath),
       testResultCaptor.capture()
     );
 
-    TestResult tr = testResultCaptor.getValue();
-    assertFalse(tr.success);
-    assertEquals(3, tr.dependencyCount);
-    assertTrue(tr.issues.vulnerabilities.size() > 0);
-    assertEquals("maven", tr.packageManager);
-    assertEquals(testSetup.org, tr.organisation.id);
+    MonitoredArtifact result = testResultCaptor.getValue();
+    assertTrue(result.getVulnSummary().getTotalCount() > 0);
   }
 
   @Test
@@ -252,19 +236,15 @@ public class ScannerModuleTest {
 
     spyScanner.scanArtifact(repoPath);
 
-    ArgumentCaptor<TestResult> testResultCaptor = ArgumentCaptor.forClass(TestResult.class);
+    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
 
     verify(spyScanner, times(1)).updateProperties(
       eq(repoPath),
       testResultCaptor.capture()
     );
 
-    TestResult tr = testResultCaptor.getValue();
-    assertTrue(tr.success);
-    assertEquals(0, tr.dependencyCount);
-    assertEquals(0, tr.issues.vulnerabilities.size());
-    assertEquals("pip", tr.packageManager);
-    assertEquals(testSetup.org, tr.organisation.id);
+    MonitoredArtifact result = testResultCaptor.getValue();
+    assertEquals(0, result.getVulnSummary().getTotalCount());
   }
 
   @Test
@@ -283,18 +263,14 @@ public class ScannerModuleTest {
       spyScanner.scanArtifact(repoPath);
     });
 
-    ArgumentCaptor<TestResult> testResultCaptor = ArgumentCaptor.forClass(TestResult.class);
+    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
 
     verify(spyScanner, times(1)).updateProperties(
       eq(repoPath),
       testResultCaptor.capture()
     );
 
-    TestResult tr = testResultCaptor.getValue();
-    assertFalse(tr.success);
-    assertEquals(1, tr.dependencyCount);
-    assertEquals(6, tr.issues.vulnerabilities.size());
-    assertEquals("pip", tr.packageManager);
-    assertEquals(testSetup.org, tr.organisation.id);
+    MonitoredArtifact result = testResultCaptor.getValue();
+    assertEquals(6, result.getVulnSummary().getTotalCount());
   }
 }


### PR DESCRIPTION
...instead of raw test result.

This refactor sets the scene for reading cached artifacts from properties, which will allow to skip tests when issue data is fresh.