### PR TITLE
chore: extract TestResult from MonitoredArtifact [OSM-2240]

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
@@ -1,7 +1,7 @@
 package io.snyk.plugins.artifactory;
 
 import io.snyk.plugins.artifactory.audit.AuditModule;
-import io.snyk.plugins.artifactory.configuration.ArtifactProperty;
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty;
 import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
 import io.snyk.plugins.artifactory.exception.CannotScanException;
 import io.snyk.plugins.artifactory.exception.SnykAPIFailureException;

--- a/core/src/main/java/io/snyk/plugins/artifactory/audit/AuditModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/audit/AuditModule.java
@@ -8,10 +8,10 @@ import org.artifactory.security.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD_INFO;
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO;
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD_INFO;
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO;
 
 public class AuditModule {
 

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperties.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperties.java
@@ -1,0 +1,12 @@
+package io.snyk.plugins.artifactory.configuration.properties;
+
+import java.util.Optional;
+
+public interface ArtifactProperties {
+
+  Optional<String> getProperty(ArtifactProperty key);
+
+  void setProperty(ArtifactProperty property, String value);
+
+  boolean hasProperty(ArtifactProperty property);
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperty.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperty.java
@@ -1,4 +1,4 @@
-package io.snyk.plugins.artifactory.configuration;
+package io.snyk.plugins.artifactory.configuration.properties;
 
 public enum ArtifactProperty {
   ISSUE_URL("snyk.issue.url"),

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/RepositoryArtifactProperties.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/RepositoryArtifactProperties.java
@@ -1,0 +1,33 @@
+package io.snyk.plugins.artifactory.configuration.properties;
+
+import org.artifactory.repo.RepoPath;
+import org.artifactory.repo.Repositories;
+
+import java.util.Optional;
+
+public class RepositoryArtifactProperties implements ArtifactProperties {
+
+  private final RepoPath repoPath;
+  private final Repositories repositories;
+
+  public RepositoryArtifactProperties(RepoPath repoPath, Repositories repositories) {
+
+    this.repoPath = repoPath;
+    this.repositories = repositories;
+  }
+
+  @Override
+  public Optional<String> getProperty(ArtifactProperty key) {
+    return Optional.ofNullable(repositories.getProperty(repoPath, key.propertyKey()));
+  }
+
+  @Override
+  public void setProperty(ArtifactProperty property, String value) {
+    repositories.setProperty(repoPath, property.propertyKey(), value);
+  }
+
+  @Override
+  public boolean hasProperty(ArtifactProperty property) {
+    return repositories.hasProperty(repoPath, property.propertyKey());
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/Ignores.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/Ignores.java
@@ -1,11 +1,11 @@
 package io.snyk.plugins.artifactory.model;
 
-import io.snyk.plugins.artifactory.configuration.ArtifactProperty;
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty;
 import org.artifactory.repo.RepoPath;
 import org.artifactory.repo.Repositories;
 
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
-import static io.snyk.plugins.artifactory.configuration.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
 
 public class Ignores {
 

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
@@ -1,40 +1,48 @@
 package io.snyk.plugins.artifactory.model;
 
-import java.net.URI;
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty;
+
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.*;
 
 public class MonitoredArtifact {
 
   private final String path;
-  private final IssueSummary vulnSummary;
-  private final IssueSummary licenseSummary;
-  private final Ignores ignores;
-  private final URI detailsUrl;
 
-  public MonitoredArtifact(String path, IssueSummary vulnSummary, IssueSummary licenseSummary, Ignores ignores, URI detailsUrl) {
+  private TestResult testResult;
+
+  private final Ignores ignores;
+
+  public MonitoredArtifact(String path, TestResult testResult, Ignores ignores) {
     this.path = path;
-    this.vulnSummary = vulnSummary;
-    this.licenseSummary = licenseSummary;
+    this.testResult = testResult;
     this.ignores = ignores;
-    this.detailsUrl = detailsUrl;
   }
 
   public String getPath() {
     return path;
   }
 
-  public IssueSummary getVulnSummary() {
-    return vulnSummary;
-  }
-
-  public IssueSummary getLicenseSummary() {
-    return licenseSummary;
+  public TestResult getTestResult() {
+    return testResult;
   }
 
   public Ignores getIgnores() {
     return ignores;
   }
 
-  public URI getDetailsUrl() {
-    return detailsUrl;
+  public void write(ArtifactProperties properties) {
+    testResult.write(properties);
+
+    setDefaultArtifactProperty(properties, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD, "false");
+    setDefaultArtifactProperty(properties, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO, "");
+    setDefaultArtifactProperty(properties, ISSUE_LICENSES_FORCE_DOWNLOAD, "false");
+    setDefaultArtifactProperty(properties, ISSUE_LICENSES_FORCE_DOWNLOAD_INFO, "");
+  }
+
+  private void setDefaultArtifactProperty(ArtifactProperties properties, ArtifactProperty property, String value) {
+    if (!properties.hasProperty(property)) {
+      properties.setProperty(property, value);
+    }
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
@@ -1,0 +1,44 @@
+package io.snyk.plugins.artifactory.model;
+
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.*;
+
+public class TestResult {
+  private final ZonedDateTime timestamp;
+  private final IssueSummary vulnSummary;
+  private final IssueSummary licenseSummary;
+  private final URI detailsUrl;
+
+  public TestResult(IssueSummary vulnSummary, IssueSummary licenseSummary, URI detailsUrl) {
+    this.timestamp = ZonedDateTime.now();
+    this.vulnSummary = vulnSummary;
+    this.licenseSummary = licenseSummary;
+    this.detailsUrl = detailsUrl;
+  }
+
+  public IssueSummary getVulnSummary() {
+    return vulnSummary;
+  }
+
+  public IssueSummary getLicenseSummary() {
+    return licenseSummary;
+  }
+
+  public URI getDetailsUrl() {
+    return detailsUrl;
+  }
+
+  public ZonedDateTime getTimestamp() {
+    return timestamp;
+  }
+
+  public void write(ArtifactProperties properties) {
+    properties.setProperty(ISSUE_VULNERABILITIES, getVulnSummary().toString());
+    properties.setProperty(ISSUE_LICENSES, getLicenseSummary().toString());
+    properties.setProperty(ISSUE_URL, getDetailsUrl().toString());
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
@@ -5,7 +5,6 @@ import io.snyk.plugins.artifactory.exception.CannotScanException;
 import io.snyk.plugins.artifactory.exception.SnykAPIFailureException;
 import io.snyk.sdk.api.v1.SnykClient;
 import io.snyk.sdk.api.v1.SnykResult;
-import io.snyk.sdk.model.TestResult;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 import org.slf4j.Logger;
@@ -33,7 +32,7 @@ class MavenScanner implements PackageScanner {
     return "https://snyk.io/vuln/" + URLEncoder.encode("maven:" + groupID + ":" + artifactID + "@" + artifactVersion, UTF_8);
   }
 
-  public TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
+  public io.snyk.plugins.artifactory.model.TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
     String groupID = Optional.ofNullable(fileLayoutInfo.getOrganization())
       .orElseThrow(() -> new CannotScanException("Group ID not provided."));
     String artifactID = Optional.ofNullable(fileLayoutInfo.getModule())
@@ -41,7 +40,7 @@ class MavenScanner implements PackageScanner {
     String artifactVersion = Optional.ofNullable(fileLayoutInfo.getBaseRevision())
       .orElseThrow(() -> new CannotScanException("Artifact Version not provided."));
 
-    SnykResult<TestResult> result;
+    SnykResult<io.snyk.sdk.model.TestResult> result;
     try {
       result = snykClient.testMaven(
         groupID,
@@ -54,8 +53,8 @@ class MavenScanner implements PackageScanner {
       throw new SnykAPIFailureException(e);
     }
 
-    TestResult testResult = result.get().orElseThrow(() -> new SnykAPIFailureException(result));
+    io.snyk.sdk.model.TestResult testResult = result.get().orElseThrow(() -> new SnykAPIFailureException(result));
     testResult.packageDetailsURL = getArtifactDetailsURL(groupID, artifactID, artifactVersion);
-    return testResult;
+    return TestResultConverter.convert(testResult);
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/NpmScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/NpmScanner.java
@@ -10,13 +10,11 @@ import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 import org.slf4j.Logger;
 
-import java.net.URLEncoder;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.slf4j.LoggerFactory.getLogger;
 
 class NpmScanner implements PackageScanner {
@@ -47,7 +45,7 @@ class NpmScanner implements PackageScanner {
     return "https://snyk.io/test/npm/" + details.name + "/" + details.version;
   }
 
-  public TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
+  public io.snyk.plugins.artifactory.model.TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
     PackageURLDetails details = getPackageDetailsFromUrl(repoPath.toString())
       .orElseThrow(() -> new CannotScanException("Package details not provided."));
 
@@ -64,7 +62,7 @@ class NpmScanner implements PackageScanner {
 
     TestResult testResult = result.get().orElseThrow(() -> new SnykAPIFailureException(result));
     testResult.packageDetailsURL = getPackageDetailsURL(details);
-    return testResult;
+    return TestResultConverter.convert(testResult);
   }
 
   public static class PackageURLDetails {

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageScanner.java
@@ -1,6 +1,6 @@
 package io.snyk.plugins.artifactory.scanner;
 
-import io.snyk.sdk.model.TestResult;
+import io.snyk.plugins.artifactory.model.TestResult;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
@@ -27,7 +27,7 @@ public class PackageValidator {
 
   private void validateVulnerabilityIssues(MonitoredArtifact artifact) {
     validateIssues(
-      artifact.getVulnSummary(),
+      artifact.getTestResult().getVulnSummary(),
       settings.getVulnSeverityThreshold(),
       artifact.getIgnores().shouldIgnoreVulnIssues(),
       format("VULNERABILITIES, %s", artifact.getPath())
@@ -36,7 +36,7 @@ public class PackageValidator {
 
   private void validateLicenseIssues(MonitoredArtifact artifact) {
     validateIssues(
-      artifact.getLicenseSummary(),
+      artifact.getTestResult().getLicenseSummary(),
       settings.getLicenseSeverityThreshold(),
       artifact.getIgnores().shouldIgnoreLicenseIssues(),
       format("LICENSES, %s", artifact.getPath())

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
@@ -59,7 +59,7 @@ class PythonScanner implements PackageScanner {
     return "https://snyk.io/vuln/" + URLEncoder.encode("pip:" + details.name + "@" + details.version, UTF_8);
   }
 
-  public TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
+  public io.snyk.plugins.artifactory.model.TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
     ModuleURLDetails details = getModuleDetailsFromFileLayoutInfo(fileLayoutInfo)
       .orElseGet(() -> getModuleDetailsFromUrl(repoPath.toString())
         .orElseThrow(() -> new CannotScanException("Module details not provided.")));
@@ -77,7 +77,7 @@ class PythonScanner implements PackageScanner {
 
     TestResult testResult = result.get().orElseThrow(() -> new SnykAPIFailureException(result));
     testResult.packageDetailsURL = getModuleDetailsURL(details);
-    return testResult;
+    return TestResultConverter.convert(testResult);
   }
 
   public static class ModuleURLDetails {

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/TestResultConverter.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/TestResultConverter.java
@@ -1,0 +1,17 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import io.snyk.plugins.artifactory.model.IssueSummary;
+import io.snyk.plugins.artifactory.model.TestResult;
+
+import java.net.URI;
+
+public class TestResultConverter {
+
+  public static TestResult convert(io.snyk.sdk.model.TestResult result) {
+    return new TestResult(
+      IssueSummary.from(result.issues.vulnerabilities),
+      IssueSummary.from(result.issues.licenses),
+      URI.create(result.packageDetailsURL)
+    );
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/configuration/properties/FakeArtifactProperties.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/configuration/properties/FakeArtifactProperties.java
@@ -1,0 +1,25 @@
+package io.snyk.plugins.artifactory.configuration.properties;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeArtifactProperties implements ArtifactProperties {
+
+  private Map<ArtifactProperty, String> properties = new HashMap<>();
+
+  @Override
+  public Optional<String> getProperty(ArtifactProperty key) {
+    return Optional.ofNullable(properties.get(key));
+  }
+
+  @Override
+  public void setProperty(ArtifactProperty property, String value) {
+    properties.put(property, value);
+  }
+
+  @Override
+  public boolean hasProperty(ArtifactProperty property) {
+    return properties.containsKey(property);
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/model/MonitoredArtifactTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/model/MonitoredArtifactTest.java
@@ -1,0 +1,65 @@
+package io.snyk.plugins.artifactory.model;
+
+import io.snyk.plugins.artifactory.configuration.properties.FakeArtifactProperties;
+import io.snyk.sdk.model.Severity;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MonitoredArtifactTest {
+
+  @Test
+  void write_firstTime() {
+    FakeArtifactProperties properties = new FakeArtifactProperties();
+    MonitoredArtifact artifact = new MonitoredArtifact("electron",
+      new TestResult(
+        IssueSummary.from(Stream.of(Severity.CRITICAL)),
+        IssueSummary.from(Stream.of(Severity.MEDIUM)),
+        URI.create("https://app.snyk.io/package/electron/1.0.0")
+      ),
+      new Ignores()
+    );
+
+    artifact.write(properties);
+
+    assertEquals("1 critical, 0 high, 0 medium, 0 low", properties.getProperty(ISSUE_VULNERABILITIES).get());
+    assertEquals("0 critical, 0 high, 1 medium, 0 low", properties.getProperty(ISSUE_LICENSES).get());
+    assertEquals("https://app.snyk.io/package/electron/1.0.0", properties.getProperty(ISSUE_URL).get());
+    assertEquals("false", properties.getProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD).get());
+    assertEquals("", properties.getProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO).get());
+    assertEquals("false", properties.getProperty(ISSUE_LICENSES_FORCE_DOWNLOAD).get());
+    assertEquals("", properties.getProperty(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO).get());
+  }
+
+  @Test
+  void write_whenPropertiesHadBeenSetBefore() {
+    FakeArtifactProperties properties = new FakeArtifactProperties();
+    properties.setProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD, "true");
+    properties.setProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO, "issue ignored by prodsec");
+    properties.setProperty(ISSUE_LICENSES_FORCE_DOWNLOAD, "true");
+    properties.setProperty(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO, "issue ignored by legal");
+    MonitoredArtifact artifact = new MonitoredArtifact("electron",
+      new TestResult(
+        IssueSummary.from(Stream.of(Severity.HIGH)),
+        IssueSummary.from(Stream.of(Severity.LOW)),
+        URI.create("https://app.snyk.io/package/electron/2.0.0")
+
+      ),
+      new Ignores()
+      );
+
+    artifact.write(properties);
+
+    assertEquals("0 critical, 1 high, 0 medium, 0 low", properties.getProperty(ISSUE_VULNERABILITIES).get());
+    assertEquals("0 critical, 0 high, 0 medium, 1 low", properties.getProperty(ISSUE_LICENSES).get());
+    assertEquals("https://app.snyk.io/package/electron/2.0.0", properties.getProperty(ISSUE_URL).get());
+    assertEquals("true", properties.getProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD).get());
+    assertEquals("issue ignored by prodsec", properties.getProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO).get());
+    assertEquals("true", properties.getProperty(ISSUE_LICENSES_FORCE_DOWNLOAD).get());
+    assertEquals("issue ignored by legal", properties.getProperty(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO).get());
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/MavenScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/MavenScannerTest.java
@@ -2,10 +2,10 @@ package io.snyk.plugins.artifactory.scanner;
 
 import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
 import io.snyk.plugins.artifactory.exception.CannotScanException;
+import io.snyk.plugins.artifactory.model.TestResult;
 import io.snyk.plugins.artifactory.util.SnykConfigForTests;
 import io.snyk.sdk.SnykConfig;
 import io.snyk.sdk.api.v1.SnykClient;
-import io.snyk.sdk.model.TestResult;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 import org.junit.jupiter.api.Assertions;
@@ -40,13 +40,9 @@ public class MavenScannerTest {
     when(fileLayoutInfo.getBaseRevision()).thenReturn("2.9.8");
 
     TestResult result = scanner.scan(fileLayoutInfo, repoPath);
-    assertFalse(result.success); // false because it has vulns
-    assertEquals(3, result.dependencyCount);
-    assertTrue(result.issues.vulnerabilities.size() > 0);
-    assertEquals("maven", result.packageManager);
-    assertEquals(org, result.organisation.id);
+    assertTrue(result.getVulnSummary().getTotalCount() > 0);
     assertEquals("https://snyk.io/vuln/maven%3Acom.fasterxml.jackson.core%3Ajackson-databind%402.9.8",
-      result.packageDetailsURL
+      result.getDetailsUrl().toString()
     );
   }
 

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/NpmScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/NpmScannerTest.java
@@ -1,10 +1,10 @@
 package io.snyk.plugins.artifactory.scanner;
 
 import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
+import io.snyk.plugins.artifactory.model.TestResult;
 import io.snyk.plugins.artifactory.util.SnykConfigForTests;
 import io.snyk.sdk.SnykConfig;
 import io.snyk.sdk.api.v1.SnykClient;
-import io.snyk.sdk.model.TestResult;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 import org.junit.jupiter.api.Assertions;
@@ -37,12 +37,8 @@ public class NpmScannerTest {
     FileLayoutInfo fileLayoutInfo = mock(FileLayoutInfo.class);
 
     TestResult result = scanner.scan(fileLayoutInfo, repoPath);
-    assertFalse(result.success);
-    assertEquals(1, result.dependencyCount);
-    assertTrue(result.issues.vulnerabilities.size() > 0);
-    assertEquals("npm", result.packageManager);
-    assertEquals(org, result.organisation.id);
-    assertEquals("https://snyk.io/test/npm/lodash/4.17.15", result.packageDetailsURL);
+    assertTrue(result.getVulnSummary().getTotalCount() > 0);
+    assertEquals("https://snyk.io/test/npm/lodash/4.17.15", result.getDetailsUrl().toString());
   }
 
   @Test

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/PackageValidatorTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/PackageValidatorTest.java
@@ -1,9 +1,6 @@
 package io.snyk.plugins.artifactory.scanner;
 
-import io.snyk.plugins.artifactory.model.Ignores;
-import io.snyk.plugins.artifactory.model.IssueSummary;
-import io.snyk.plugins.artifactory.model.MonitoredArtifact;
-import io.snyk.plugins.artifactory.model.ValidationSettings;
+import io.snyk.plugins.artifactory.model.*;
 import io.snyk.sdk.model.Severity;
 import org.artifactory.exception.CancelException;
 import org.junit.jupiter.api.Test;
@@ -23,10 +20,12 @@ class PackageValidatorTest {
       .withLicenseSeverityThreshold(Severity.CRITICAL);
     PackageValidator validator = new PackageValidator(settings);
     MonitoredArtifact artifact = new MonitoredArtifact("",
-      IssueSummary.from(Stream.of(Severity.LOW)),
-      IssueSummary.from(Stream.of(Severity.MEDIUM)),
-      new Ignores(),
-      URI.create("https://snyk.io/package/version")
+      new TestResult(
+        IssueSummary.from(Stream.of(Severity.LOW)),
+        IssueSummary.from(Stream.of(Severity.MEDIUM)),
+        URI.create("https://snyk.io/package/version")
+      ),
+      new Ignores()
     );
 
     assertDoesNotThrow(() -> validator.validate(artifact));
@@ -39,10 +38,12 @@ class PackageValidatorTest {
       .withLicenseSeverityThreshold(Severity.LOW);
     PackageValidator validator = new PackageValidator(settings);
     MonitoredArtifact artifact = new MonitoredArtifact("",
-      IssueSummary.from(Stream.of(Severity.HIGH)),
-      IssueSummary.from(Stream.empty()),
-      new Ignores(),
-      URI.create("https://snyk.io/package/version")
+      new TestResult(
+        IssueSummary.from(Stream.of(Severity.HIGH)),
+        IssueSummary.from(Stream.empty()),
+        URI.create("https://snyk.io/package/version")
+      ),
+      new Ignores()
     );
 
     assertThrows(CancelException.class, () -> validator.validate(artifact));
@@ -55,10 +56,12 @@ class PackageValidatorTest {
       .withLicenseSeverityThreshold(Severity.LOW);
     PackageValidator validator = new PackageValidator(settings);
     MonitoredArtifact artifact = new MonitoredArtifact("",
-      IssueSummary.from(Stream.of(Severity.HIGH)),
-      IssueSummary.from(Stream.empty()),
-      new Ignores().withIgnoreVulnIssues(true),
-      URI.create("https://snyk.io/package/version")
+      new TestResult(
+        IssueSummary.from(Stream.of(Severity.HIGH)),
+        IssueSummary.from(Stream.empty()),
+        URI.create("https://snyk.io/package/version")
+      ),
+      new Ignores().withIgnoreVulnIssues(true)
     );
 
     assertDoesNotThrow(() -> validator.validate(artifact));
@@ -71,10 +74,12 @@ class PackageValidatorTest {
       .withLicenseSeverityThreshold(Severity.MEDIUM);
     PackageValidator validator = new PackageValidator(settings);
     MonitoredArtifact artifact = new MonitoredArtifact("",
-      IssueSummary.from(Stream.empty()),
-      IssueSummary.from(Stream.of(Severity.MEDIUM)),
-      new Ignores(),
-      URI.create("https://snyk.io/package/version")
+      new TestResult(
+        IssueSummary.from(Stream.empty()),
+        IssueSummary.from(Stream.of(Severity.MEDIUM)),
+        URI.create("https://snyk.io/package/version")
+      ),
+      new Ignores()
     );
 
     assertThrows(CancelException.class, () -> validator.validate(artifact));
@@ -87,10 +92,12 @@ class PackageValidatorTest {
       .withLicenseSeverityThreshold(Severity.MEDIUM);
     PackageValidator validator = new PackageValidator(settings);
     MonitoredArtifact artifact = new MonitoredArtifact("",
-      IssueSummary.from(Stream.empty()),
-      IssueSummary.from(Stream.of(Severity.MEDIUM)),
-      new Ignores().withIgnoreLicenseIssues(true),
-      URI.create("https://snyk.io/package/version")
+      new TestResult(
+        IssueSummary.from(Stream.empty()),
+        IssueSummary.from(Stream.of(Severity.MEDIUM)),
+        URI.create("https://snyk.io/package/version")
+      ),
+      new Ignores().withIgnoreLicenseIssues(true)
     );
 
     assertDoesNotThrow(() -> validator.validate(artifact));

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
@@ -2,10 +2,10 @@ package io.snyk.plugins.artifactory.scanner;
 
 import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
 import io.snyk.plugins.artifactory.exception.CannotScanException;
+import io.snyk.plugins.artifactory.model.TestResult;
 import io.snyk.plugins.artifactory.util.SnykConfigForTests;
 import io.snyk.sdk.SnykConfig;
 import io.snyk.sdk.api.v1.SnykClient;
-import io.snyk.sdk.model.TestResult;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 import org.junit.jupiter.api.Assertions;
@@ -39,12 +39,8 @@ public class PythonScannerTest {
     when(fileLayoutInfo.getBaseRevision()).thenReturn("1.25.7");
 
     TestResult result = scanner.scan(fileLayoutInfo, repoPath);
-    assertFalse(result.success);
-    assertEquals(1, result.dependencyCount);
-    assertEquals(6, result.issues.vulnerabilities.size());
-    assertEquals("pip", result.packageManager);
-    assertEquals(org, result.organisation.id);
-    assertEquals("https://snyk.io/vuln/pip%3Aurllib3%401.25.7", result.packageDetailsURL);
+    assertEquals(6, result.getVulnSummary().getTotalCount());
+    assertEquals("https://snyk.io/vuln/pip%3Aurllib3%401.25.7", result.getDetailsUrl().toString());
   }
 
   @Test

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -7,13 +7,11 @@ import io.snyk.plugins.artifactory.model.MonitoredArtifact;
 import io.snyk.plugins.artifactory.util.SnykConfigForTests;
 import io.snyk.sdk.SnykConfig;
 import io.snyk.sdk.api.v1.SnykClient;
-import org.artifactory.exception.CancelException;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 import org.artifactory.repo.Repositories;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
@@ -23,9 +21,9 @@ import java.util.Properties;
 import java.util.function.Function;
 
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.*;
-import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.SCANNER_PACKAGE_TYPE_PYPI;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ScannerModuleTest {
 
@@ -131,17 +129,9 @@ public class ScannerModuleTest {
     when(repoPath.getPath()).thenReturn("myArtifact.tgz");
     when(repoPath.toString()).thenReturn("npm:minimist/-/minimist-1.2.6.tgz");
 
-    spyScanner.scanArtifact(repoPath);
+    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
 
-    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
-
-    verify(spyScanner, times(1)).updateProperties(
-      eq(repoPath),
-      testResultCaptor.capture()
-    );
-
-    MonitoredArtifact result = testResultCaptor.getValue();
-    assertEquals(0, result.getVulnSummary().getTotalCount());
+    assertEquals(0, result.getTestResult().getVulnSummary().getTotalCount());
   }
 
   @Test
@@ -156,19 +146,8 @@ public class ScannerModuleTest {
     when(repoPath.getPath()).thenReturn("myArtifact.tgz");
     when(repoPath.toString()).thenReturn("npm:lodash/-/lodash-4.17.15.tgz");
 
-    Assertions.assertThrows(CancelException.class, () -> {
-      spyScanner.scanArtifact(repoPath);
-    });
-
-    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
-
-    verify(spyScanner, times(1)).updateProperties(
-      eq(repoPath),
-      testResultCaptor.capture()
-    );
-
-    MonitoredArtifact result = testResultCaptor.getValue();
-    assertTrue(result.getVulnSummary().getTotalCount() > 0);
+    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    assertTrue(result.getTestResult().getVulnSummary().getTotalCount() > 0);
   }
 
   @Test
@@ -183,17 +162,8 @@ public class ScannerModuleTest {
     RepoPath repoPath = testSetup.repoPath;
     when(repoPath.getPath()).thenReturn("myArtifact.jar");
 
-    spyScanner.scanArtifact(repoPath);
-
-    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
-
-    verify(spyScanner, times(1)).updateProperties(
-      eq(repoPath),
-      testResultCaptor.capture()
-    );
-
-    MonitoredArtifact result = testResultCaptor.getValue();
-    assertEquals(0, result.getVulnSummary().getTotalCount());
+    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    assertEquals(0, result.getTestResult().getVulnSummary().getTotalCount());
   }
 
   @Test
@@ -208,19 +178,8 @@ public class ScannerModuleTest {
     RepoPath repoPath = testSetup.repoPath;
     when(repoPath.getPath()).thenReturn("myArtifact.jar");
 
-    Assertions.assertThrows(CancelException.class, () -> {
-      spyScanner.scanArtifact(repoPath);
-    });
-
-    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
-
-    verify(spyScanner, times(1)).updateProperties(
-      eq(repoPath),
-      testResultCaptor.capture()
-    );
-
-    MonitoredArtifact result = testResultCaptor.getValue();
-    assertTrue(result.getVulnSummary().getTotalCount() > 0);
+    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    assertTrue(result.getTestResult().getVulnSummary().getTotalCount() > 0);
   }
 
   @Test
@@ -234,17 +193,8 @@ public class ScannerModuleTest {
     RepoPath repoPath = testSetup.repoPath;
     when(repoPath.getPath()).thenReturn("myArtifact.whl");
 
-    spyScanner.scanArtifact(repoPath);
-
-    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
-
-    verify(spyScanner, times(1)).updateProperties(
-      eq(repoPath),
-      testResultCaptor.capture()
-    );
-
-    MonitoredArtifact result = testResultCaptor.getValue();
-    assertEquals(0, result.getVulnSummary().getTotalCount());
+    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    assertEquals(0, result.getTestResult().getVulnSummary().getTotalCount());
   }
 
   @Test
@@ -258,19 +208,7 @@ public class ScannerModuleTest {
     RepoPath repoPath = testSetup.repoPath;
     when(repoPath.getPath()).thenReturn("myArtifact.whl");
 
-
-    Assertions.assertThrows(CancelException.class, () -> {
-      spyScanner.scanArtifact(repoPath);
-    });
-
-    ArgumentCaptor<MonitoredArtifact> testResultCaptor = ArgumentCaptor.forClass(MonitoredArtifact.class);
-
-    verify(spyScanner, times(1)).updateProperties(
-      eq(repoPath),
-      testResultCaptor.capture()
-    );
-
-    MonitoredArtifact result = testResultCaptor.getValue();
-    assertEquals(6, result.getVulnSummary().getTotalCount());
+    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    assertEquals(6, result.getTestResult().getVulnSummary().getTotalCount());
   }
 }


### PR DESCRIPTION
Adding structure to `MonitoredArtifact` and pushing the `TestResult` model into the scanners. Also moving property writing logic into model classes.

This is the final refactor before implementing retrieval of test results from properties to reduce number of requests to Snyk API.