### PR TITLE
feat: skip Snyk tests when cache is fresh [OSM-2240]

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -44,6 +44,12 @@ snyk.api.organization=
 # Scanner Configuration
 # =====================
 
+# Scan result expiry. When the most recent scan was made within this time frame,
+# filtering respects the previous result. Beyond that time, a new Snyk Test request is made.
+# When this property is set to 0, the plugin triggers a test each time an artifact is accessed.
+# Default: 168 (1 week)
+#snyk.scanner.frequency.hours=168
+
 # By default, if Snyk API fails while scanning an artifact for any reason, the download will be allowed.
 # Setting this property to "true" will block downloads when Snyk API fails.
 # Accepts: "true", "false"

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -18,7 +18,8 @@ public enum PluginConfiguration implements Configuration {
   SCANNER_LICENSE_THRESHOLD("snyk.scanner.license.threshold", "low"),
   SCANNER_PACKAGE_TYPE_MAVEN("snyk.scanner.packageType.maven", "true"),
   SCANNER_PACKAGE_TYPE_NPM("snyk.scanner.packageType.npm", "true"),
-  SCANNER_PACKAGE_TYPE_PYPI("snyk.scanner.packageType.pypi", "false");
+  SCANNER_PACKAGE_TYPE_PYPI("snyk.scanner.packageType.pypi", "false"),
+  TEST_FREQUENCY_HOURS("snyk.scanner.frequency.hours", "168");
 
   private final String propertyKey;
   private final String defaultValue;

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperties.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperties.java
@@ -4,9 +4,11 @@ import java.util.Optional;
 
 public interface ArtifactProperties {
 
-  Optional<String> getProperty(ArtifactProperty key);
+  String getArtifactPath();
 
-  void setProperty(ArtifactProperty property, String value);
+  Optional<String> get(ArtifactProperty key);
 
-  boolean hasProperty(ArtifactProperty property);
+  void set(ArtifactProperty property, String value);
+
+  boolean has(ArtifactProperty property);
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperty.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperty.java
@@ -1,6 +1,7 @@
 package io.snyk.plugins.artifactory.configuration.properties;
 
 public enum ArtifactProperty {
+  TEST_TIMESTAMP("snyk.test.timestamp"),
   ISSUE_URL("snyk.issue.url"),
   ISSUE_VULNERABILITIES("snyk.issue.vulnerabilities"),
   ISSUE_VULNERABILITIES_FORCE_DOWNLOAD("snyk.issue.vulnerabilities.forceDownload"),

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/RepositoryArtifactProperties.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/RepositoryArtifactProperties.java
@@ -17,17 +17,22 @@ public class RepositoryArtifactProperties implements ArtifactProperties {
   }
 
   @Override
-  public Optional<String> getProperty(ArtifactProperty key) {
+  public String getArtifactPath() {
+    return repoPath.toString();
+  }
+
+  @Override
+  public Optional<String> get(ArtifactProperty key) {
     return Optional.ofNullable(repositories.getProperty(repoPath, key.propertyKey()));
   }
 
   @Override
-  public void setProperty(ArtifactProperty property, String value) {
+  public void set(ArtifactProperty property, String value) {
     repositories.setProperty(repoPath, property.propertyKey(), value);
   }
 
   @Override
-  public boolean hasProperty(ArtifactProperty property) {
+  public boolean has(ArtifactProperty property) {
     return repositories.hasProperty(repoPath, property.propertyKey());
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/Ignores.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/Ignores.java
@@ -1,8 +1,9 @@
 package io.snyk.plugins.artifactory.model;
 
-import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty;
-import org.artifactory.repo.RepoPath;
-import org.artifactory.repo.Repositories;
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
+
+import java.util.Objects;
+import java.util.Optional;
 
 import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.ISSUE_LICENSES_FORCE_DOWNLOAD;
 import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.ISSUE_VULNERABILITIES_FORCE_DOWNLOAD;
@@ -38,15 +39,30 @@ public class Ignores {
     return new Ignores(ignoreVulnIssues, ignoreLicenseIssues);
   }
 
-  public static Ignores fromProperties(Repositories repositories, RepoPath repoPath) {
-    boolean ignoreVulnIssues = readIgnoreFlag(repositories, repoPath, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD);
-    boolean ignoreLicenseIssues = readIgnoreFlag(repositories, repoPath, ISSUE_LICENSES_FORCE_DOWNLOAD);
+  public static Ignores read(ArtifactProperties properties) {
+    boolean ignoreVulnIssues = properties.get(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD).equals(Optional.of("true"));
+    boolean ignoreLicenseIssues = properties.get(ISSUE_LICENSES_FORCE_DOWNLOAD).equals(Optional.of("true"));
     return new Ignores(ignoreVulnIssues, ignoreLicenseIssues);
   }
 
-  private static boolean readIgnoreFlag(Repositories repositories, RepoPath repoPath, ArtifactProperty property) {
-    final String vulnerabilitiesForceDownloadProperty = property.propertyKey();
-    final String vulnerabilitiesForceDownload = repositories.getProperty(repoPath, vulnerabilitiesForceDownloadProperty);
-    return "true".equalsIgnoreCase(vulnerabilitiesForceDownload);
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Ignores ignores = (Ignores) o;
+    return ignoreVulnIssues == ignores.ignoreVulnIssues && ignoreLicenseIssues == ignores.ignoreLicenseIssues;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ignoreVulnIssues, ignoreLicenseIssues);
+  }
+
+  @Override
+  public String toString() {
+    return "Ignores{" +
+        "ignoreVulnIssues=" + ignoreVulnIssues +
+        ", ignoreLicenseIssues=" + ignoreLicenseIssues +
+        '}';
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
@@ -3,6 +3,9 @@ package io.snyk.plugins.artifactory.model;
 import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
 import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.*;
 
 public class MonitoredArtifact {
@@ -31,18 +34,52 @@ public class MonitoredArtifact {
     return ignores;
   }
 
-  public void write(ArtifactProperties properties) {
+  public MonitoredArtifact write(ArtifactProperties properties) {
     testResult.write(properties);
 
     setDefaultArtifactProperty(properties, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD, "false");
     setDefaultArtifactProperty(properties, ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO, "");
     setDefaultArtifactProperty(properties, ISSUE_LICENSES_FORCE_DOWNLOAD, "false");
     setDefaultArtifactProperty(properties, ISSUE_LICENSES_FORCE_DOWNLOAD_INFO, "");
+
+    return this;
   }
 
   private void setDefaultArtifactProperty(ArtifactProperties properties, ArtifactProperty property, String value) {
-    if (!properties.hasProperty(property)) {
-      properties.setProperty(property, value);
+    if (!properties.has(property)) {
+      properties.set(property, value);
     }
+  }
+
+  public static Optional<MonitoredArtifact> read(ArtifactProperties properties) {
+    return TestResult.read(properties).map(testResult ->
+        new MonitoredArtifact(
+            properties.getArtifactPath(),
+            testResult,
+            Ignores.read(properties)
+        )
+    );
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MonitoredArtifact artifact = (MonitoredArtifact) o;
+    return Objects.equals(path, artifact.path) && Objects.equals(testResult, artifact.testResult) && Objects.equals(ignores, artifact.ignores);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(path, testResult, ignores);
+  }
+
+  @Override
+  public String toString() {
+    return "MonitoredArtifact{" +
+        "path='" + path + '\'' +
+        ", testResult=" + testResult +
+        ", ignores=" + ignores +
+        '}';
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
@@ -4,6 +4,8 @@ import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
 
 import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.*;
 
@@ -14,7 +16,11 @@ public class TestResult {
   private final URI detailsUrl;
 
   public TestResult(IssueSummary vulnSummary, IssueSummary licenseSummary, URI detailsUrl) {
-    this.timestamp = ZonedDateTime.now();
+    this(ZonedDateTime.now(), vulnSummary, licenseSummary, detailsUrl);
+  }
+
+  private TestResult(ZonedDateTime timestamp, IssueSummary vulnSummary, IssueSummary licenseSummary, URI detailsUrl) {
+    this.timestamp = timestamp;
     this.vulnSummary = vulnSummary;
     this.licenseSummary = licenseSummary;
     this.detailsUrl = detailsUrl;
@@ -37,8 +43,49 @@ public class TestResult {
   }
 
   public void write(ArtifactProperties properties) {
-    properties.setProperty(ISSUE_VULNERABILITIES, getVulnSummary().toString());
-    properties.setProperty(ISSUE_LICENSES, getLicenseSummary().toString());
-    properties.setProperty(ISSUE_URL, getDetailsUrl().toString());
+    properties.set(TEST_TIMESTAMP, timestamp.toString());
+    properties.set(ISSUE_VULNERABILITIES, getVulnSummary().toString());
+    properties.set(ISSUE_LICENSES, getLicenseSummary().toString());
+    properties.set(ISSUE_URL, getDetailsUrl().toString());
+  }
+
+  public static Optional<TestResult> read(ArtifactProperties properties) {
+    Optional<ZonedDateTime> timestamp = properties.get(TEST_TIMESTAMP).map(ZonedDateTime::parse);
+    Optional<IssueSummary> vulns = properties.get(ISSUE_VULNERABILITIES).flatMap(IssueSummary::parse);
+    Optional<IssueSummary> licenses = properties.get(ISSUE_LICENSES).flatMap(IssueSummary::parse);
+    Optional<URI> detailsUrl = properties.get(ISSUE_URL).map(URI::create);
+
+    if(timestamp.isEmpty() || vulns.isEmpty() || licenses.isEmpty() || detailsUrl.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(new TestResult(
+      timestamp.get(),
+      vulns.get(),
+      licenses.get(),
+      detailsUrl.get()
+    ));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TestResult that = (TestResult) o;
+    return Objects.equals(timestamp, that.timestamp) && Objects.equals(vulnSummary, that.vulnSummary) && Objects.equals(licenseSummary, that.licenseSummary) && Objects.equals(detailsUrl, that.detailsUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(timestamp, vulnSummary, licenseSummary, detailsUrl);
+  }
+
+  @Override
+  public String toString() {
+    return "TestResult{" +
+      "timestamp=" + timestamp +
+      ", vulnSummary=" + vulnSummary +
+      ", licenseSummary=" + licenseSummary +
+      ", detailsUrl=" + detailsUrl +
+      '}';
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ArtifactCache.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ArtifactCache.java
@@ -1,0 +1,45 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
+import io.snyk.plugins.artifactory.model.MonitoredArtifact;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class ArtifactCache {
+
+  private static final Logger LOG = getLogger(ArtifactCache.class);
+
+  private final Duration frequency;
+
+  public ArtifactCache(Duration frequency) {
+    this.frequency = frequency;
+  }
+
+  public Optional<MonitoredArtifact> getCachedArtifact(ArtifactProperties properties) {
+    try {
+      return MonitoredArtifact.read(properties).filter(this::checkIfRecent);
+    } catch (RuntimeException e) {
+      return Optional.empty();
+    }
+  }
+
+  private boolean checkIfRecent(MonitoredArtifact artifact) {
+    ZonedDateTime testTime = artifact.getTestResult().getTimestamp();
+    ZonedDateTime expiry = testTime.plus(frequency);
+    boolean recent = expiry.isAfter(ZonedDateTime.now());
+
+    if(recent) {
+      LOG.debug("Found recent artifact vuln info: {} was last tested {}", artifact.getPath(), testTime);
+    } else {
+      LOG.debug("Stale artifact vuln info: {} was last tested {}", artifact.getPath(), testTime);
+    }
+
+    return recent;
+  }
+
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
@@ -42,6 +42,7 @@ class MavenScanner implements PackageScanner {
 
     SnykResult<io.snyk.sdk.model.TestResult> result;
     try {
+      LOG.debug("Running Snyk test: {}", repoPath);
       result = snykClient.testMaven(
         groupID,
         artifactID,

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/NpmScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/NpmScanner.java
@@ -51,6 +51,7 @@ class NpmScanner implements PackageScanner {
 
     SnykResult<TestResult> result;
     try {
+      LOG.debug("Running Snyk test: {}", repoPath);
       result = snykClient.testNpm(
         details.name,
         details.version,

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
@@ -66,6 +66,7 @@ class PythonScanner implements PackageScanner {
 
     SnykResult<TestResult> result;
     try {
+      LOG.debug("Running Snyk test: {}", repoPath);
       result = snykClient.testPip(
         details.name,
         details.version,

--- a/core/src/test/java/io/snyk/plugins/artifactory/configuration/properties/FakeArtifactProperties.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/configuration/properties/FakeArtifactProperties.java
@@ -8,18 +8,29 @@ public class FakeArtifactProperties implements ArtifactProperties {
 
   private Map<ArtifactProperty, String> properties = new HashMap<>();
 
+  private String artifactPath;
+
+  public FakeArtifactProperties(String artifactPath) {
+    this.artifactPath = artifactPath;
+  }
+
   @Override
-  public Optional<String> getProperty(ArtifactProperty key) {
+  public String getArtifactPath() {
+    return artifactPath;
+  }
+
+  @Override
+  public Optional<String> get(ArtifactProperty key) {
     return Optional.ofNullable(properties.get(key));
   }
 
   @Override
-  public void setProperty(ArtifactProperty property, String value) {
+  public void set(ArtifactProperty property, String value) {
     properties.put(property, value);
   }
 
   @Override
-  public boolean hasProperty(ArtifactProperty property) {
+  public boolean has(ArtifactProperty property) {
     return properties.containsKey(property);
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/model/IssueSummaryTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/model/IssueSummaryTest.java
@@ -4,6 +4,7 @@ import io.snyk.sdk.model.Severity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,5 +39,21 @@ class IssueSummaryTest {
   @Test
   void toString_withAllSeverities() {
     assertEquals("1 critical, 2 high, 3 medium, 4 low", summary.toString());
+  }
+
+  @Test
+  void parse_matching() {
+    Optional<IssueSummary> parsed = IssueSummary.parse(summary.toString());
+
+    assertTrue(parsed.isPresent());
+    assertEquals(1, parsed.get().getCountAtOrAbove(Severity.CRITICAL));
+    assertEquals(3, parsed.get().getCountAtOrAbove(Severity.HIGH));
+    assertEquals(6, parsed.get().getCountAtOrAbove(Severity.MEDIUM));
+    assertEquals(10, parsed.get().getCountAtOrAbove(Severity.LOW));
+  }
+
+  @Test
+  void parse_invalidInput() {
+    assertFalse(IssueSummary.parse("3 medium").isPresent());
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/model/MonitoredArtifactTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/model/MonitoredArtifactTest.java
@@ -5,16 +5,18 @@ import io.snyk.sdk.model.Severity;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MonitoredArtifactTest {
 
   @Test
   void write_firstTime() {
-    FakeArtifactProperties properties = new FakeArtifactProperties();
+    FakeArtifactProperties properties = new FakeArtifactProperties("electron");
     MonitoredArtifact artifact = new MonitoredArtifact("electron",
       new TestResult(
         IssueSummary.from(Stream.of(Severity.CRITICAL)),
@@ -26,22 +28,22 @@ class MonitoredArtifactTest {
 
     artifact.write(properties);
 
-    assertEquals("1 critical, 0 high, 0 medium, 0 low", properties.getProperty(ISSUE_VULNERABILITIES).get());
-    assertEquals("0 critical, 0 high, 1 medium, 0 low", properties.getProperty(ISSUE_LICENSES).get());
-    assertEquals("https://app.snyk.io/package/electron/1.0.0", properties.getProperty(ISSUE_URL).get());
-    assertEquals("false", properties.getProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD).get());
-    assertEquals("", properties.getProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO).get());
-    assertEquals("false", properties.getProperty(ISSUE_LICENSES_FORCE_DOWNLOAD).get());
-    assertEquals("", properties.getProperty(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO).get());
+    assertEquals("1 critical, 0 high, 0 medium, 0 low", properties.get(ISSUE_VULNERABILITIES).get());
+    assertEquals("0 critical, 0 high, 1 medium, 0 low", properties.get(ISSUE_LICENSES).get());
+    assertEquals("https://app.snyk.io/package/electron/1.0.0", properties.get(ISSUE_URL).get());
+    assertEquals("false", properties.get(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD).get());
+    assertEquals("", properties.get(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO).get());
+    assertEquals("false", properties.get(ISSUE_LICENSES_FORCE_DOWNLOAD).get());
+    assertEquals("", properties.get(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO).get());
   }
 
   @Test
   void write_whenPropertiesHadBeenSetBefore() {
-    FakeArtifactProperties properties = new FakeArtifactProperties();
-    properties.setProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD, "true");
-    properties.setProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO, "issue ignored by prodsec");
-    properties.setProperty(ISSUE_LICENSES_FORCE_DOWNLOAD, "true");
-    properties.setProperty(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO, "issue ignored by legal");
+    FakeArtifactProperties properties = new FakeArtifactProperties("electron");
+    properties.set(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD, "true");
+    properties.set(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO, "issue ignored by prodsec");
+    properties.set(ISSUE_LICENSES_FORCE_DOWNLOAD, "true");
+    properties.set(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO, "issue ignored by legal");
     MonitoredArtifact artifact = new MonitoredArtifact("electron",
       new TestResult(
         IssueSummary.from(Stream.of(Severity.HIGH)),
@@ -54,12 +56,40 @@ class MonitoredArtifactTest {
 
     artifact.write(properties);
 
-    assertEquals("0 critical, 1 high, 0 medium, 0 low", properties.getProperty(ISSUE_VULNERABILITIES).get());
-    assertEquals("0 critical, 0 high, 0 medium, 1 low", properties.getProperty(ISSUE_LICENSES).get());
-    assertEquals("https://app.snyk.io/package/electron/2.0.0", properties.getProperty(ISSUE_URL).get());
-    assertEquals("true", properties.getProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD).get());
-    assertEquals("issue ignored by prodsec", properties.getProperty(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO).get());
-    assertEquals("true", properties.getProperty(ISSUE_LICENSES_FORCE_DOWNLOAD).get());
-    assertEquals("issue ignored by legal", properties.getProperty(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO).get());
+    assertEquals("0 critical, 1 high, 0 medium, 0 low", properties.get(ISSUE_VULNERABILITIES).get());
+    assertEquals("0 critical, 0 high, 0 medium, 1 low", properties.get(ISSUE_LICENSES).get());
+    assertEquals("https://app.snyk.io/package/electron/2.0.0", properties.get(ISSUE_URL).get());
+    assertEquals("true", properties.get(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD).get());
+    assertEquals("issue ignored by prodsec", properties.get(ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO).get());
+    assertEquals("true", properties.get(ISSUE_LICENSES_FORCE_DOWNLOAD).get());
+    assertEquals("issue ignored by legal", properties.get(ISSUE_LICENSES_FORCE_DOWNLOAD_INFO).get());
+  }
+
+  @Test
+  void read_whenPersistedBefore() {
+    FakeArtifactProperties properties = new FakeArtifactProperties("electron");
+    MonitoredArtifact originalArtifact = new MonitoredArtifact("electron",
+      new TestResult(
+        IssueSummary.from(Stream.of(Severity.CRITICAL)),
+        IssueSummary.from(Stream.of(Severity.MEDIUM)),
+        URI.create("https://app.snyk.io/package/electron/1.0.0")
+      ),
+      new Ignores()
+    );
+
+    originalArtifact.write(properties);
+    Optional<MonitoredArtifact> retrievedArtifact = MonitoredArtifact.read(properties);
+
+    assertTrue(retrievedArtifact.isPresent());
+    assertEquals(originalArtifact, retrievedArtifact.get());
+  }
+
+  @Test
+  void read_whenPropertiesMissing() {
+    FakeArtifactProperties properties = new FakeArtifactProperties("electron");
+
+    Optional<MonitoredArtifact> retrievedArtifact = MonitoredArtifact.read(properties);
+
+    assertTrue(retrievedArtifact.isEmpty());
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ArtifactCacheTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ArtifactCacheTest.java
@@ -50,4 +50,17 @@ class ArtifactCacheTest {
 
     assertTrue(cachedArtifact.isEmpty());
   }
+
+  @Test
+  void getCachedArtifact_whenTestFrequencyIs0() {
+    FakeArtifactProperties properties = new FakeArtifactProperties("electron");
+    TestResult recentTestResult = new TestResult(IssueSummary.from(Stream.empty()), IssueSummary.from(Stream.empty()), URI.create("https://snyk.io"));
+    MonitoredArtifact recentResult = new MonitoredArtifact("electron", recentTestResult, new Ignores());
+    recentResult.write(properties);
+    ArtifactCache cache = new ArtifactCache(Duration.ofHours(0));
+
+    Optional<MonitoredArtifact> cachedArtifact = cache.getCachedArtifact(properties);
+
+    assertTrue(cachedArtifact.isEmpty());
+  }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ArtifactCacheTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ArtifactCacheTest.java
@@ -1,0 +1,53 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty;
+import io.snyk.plugins.artifactory.configuration.properties.FakeArtifactProperties;
+import io.snyk.plugins.artifactory.model.Ignores;
+import io.snyk.plugins.artifactory.model.IssueSummary;
+import io.snyk.plugins.artifactory.model.MonitoredArtifact;
+import io.snyk.plugins.artifactory.model.TestResult;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArtifactCacheTest {
+
+  @Test
+  void getCachedArtifact_whenNothingCached() {
+    ArtifactCache cache = new ArtifactCache(Duration.ofHours(1));
+
+    assertTrue(cache.getCachedArtifact(new FakeArtifactProperties("electron")).isEmpty());
+  }
+
+  @Test
+  void getCachedArtifact_whenFreshArtifactCached() {
+    FakeArtifactProperties properties = new FakeArtifactProperties("electron");
+    TestResult recentTestResult = new TestResult(IssueSummary.from(Stream.empty()), IssueSummary.from(Stream.empty()), URI.create("https://snyk.io"));
+    MonitoredArtifact recentResult = new MonitoredArtifact("electron", recentTestResult, new Ignores());
+    recentResult.write(properties);
+    ArtifactCache cache = new ArtifactCache(Duration.ofHours(1));
+
+    Optional<MonitoredArtifact> cachedArtifact = cache.getCachedArtifact(properties);
+
+    assertEquals(Optional.of(recentResult), cachedArtifact);
+  }
+
+  @Test
+  void getCachedArtifact_whenStaleArtifactCached() {
+    FakeArtifactProperties properties = new FakeArtifactProperties("electron");
+    TestResult recentTestResult = new TestResult(IssueSummary.from(Stream.empty()), IssueSummary.from(Stream.empty()), URI.create("https://snyk.io"));
+    MonitoredArtifact recentResult = new MonitoredArtifact("electron", recentTestResult, new Ignores());
+    recentResult.write(properties);
+    properties.set(ArtifactProperty.TEST_TIMESTAMP, recentTestResult.getTimestamp().minusDays(1).toString());
+    ArtifactCache cache = new ArtifactCache(Duration.ofHours(1));
+
+    Optional<MonitoredArtifact> cachedArtifact = cache.getCachedArtifact(properties);
+
+    assertTrue(cachedArtifact.isEmpty());
+  }
+}


### PR DESCRIPTION
Introducing a new configuration property `snyk.scanner.frequency.hours` defaulting to 168 (1 week). As long as there is a test result younger than the TTL indicated by the test frequency, the plugin skips making a test and filters access based on the previous result.