### PR TITLE
feat: add extendTestDeadline param to help handle Snyk errors

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -50,6 +50,13 @@ snyk.api.organization=
 # Default: 168 (1 week)
 #snyk.scanner.frequency.hours=168
 
+# How much to extend the scan result expiry when a Snyk Test request fails.
+# In case there is a Snyk request error when the next test is due,
+# this parameter allows the plugin to use the previous test result when deciding whether to block access.
+# Beyond this extended deadline, the result of filtering will depend on the snyk.scanner.block-on-api-failure param.
+# Default: 24 hours (1 day)
+#snyk.scanner.extendTestDeadline.hours=24
+
 # By default, if Snyk API fails while scanning an artifact for any reason, the download will be allowed.
 # Setting this property to "true" will block downloads when Snyk API fails.
 # Accepts: "true", "false"

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -19,7 +19,8 @@ public enum PluginConfiguration implements Configuration {
   SCANNER_PACKAGE_TYPE_MAVEN("snyk.scanner.packageType.maven", "true"),
   SCANNER_PACKAGE_TYPE_NPM("snyk.scanner.packageType.npm", "true"),
   SCANNER_PACKAGE_TYPE_PYPI("snyk.scanner.packageType.pypi", "false"),
-  TEST_FREQUENCY_HOURS("snyk.scanner.frequency.hours", "168");
+  TEST_FREQUENCY_HOURS("snyk.scanner.frequency.hours", "168"),
+  EXTEND_TEST_DEADLINE_HOURS("snyk.scanner.extendTestDeadline.hours", "24");
 
   private final String propertyKey;
   private final String defaultValue;

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/MonitoredArtifact.java
@@ -2,13 +2,17 @@ package io.snyk.plugins.artifactory.model;
 
 import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
 import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty;
+import org.slf4j.Logger;
 
 import java.util.Objects;
 import java.util.Optional;
 
 import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.*;
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class MonitoredArtifact {
+
+  private static final Logger LOG = getLogger(MonitoredArtifact.class);
 
   private final String path;
 
@@ -52,13 +56,18 @@ public class MonitoredArtifact {
   }
 
   public static Optional<MonitoredArtifact> read(ArtifactProperties properties) {
-    return TestResult.read(properties).map(testResult ->
+    try {
+      return TestResult.read(properties).map(testResult ->
         new MonitoredArtifact(
-            properties.getArtifactPath(),
-            testResult,
-            Ignores.read(properties)
+          properties.getArtifactPath(),
+          testResult,
+          Ignores.read(properties)
         )
-    );
+      );
+    } catch (RuntimeException e) {
+      LOG.error("Failed to read artifact properties of artifact {}. Error: {}", properties.getArtifactPath(), e.getMessage());
+      return Optional.empty();
+    }
   }
 
   @Override
@@ -77,9 +86,9 @@ public class MonitoredArtifact {
   @Override
   public String toString() {
     return "MonitoredArtifact{" +
-        "path='" + path + '\'' +
-        ", testResult=" + testResult +
-        ", ignores=" + ignores +
-        '}';
+      "path='" + path + '\'' +
+      ", testResult=" + testResult +
+      ", ignores=" + ignores +
+      '}';
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
@@ -19,7 +19,7 @@ public class TestResult {
     this(ZonedDateTime.now(), vulnSummary, licenseSummary, detailsUrl);
   }
 
-  private TestResult(ZonedDateTime timestamp, IssueSummary vulnSummary, IssueSummary licenseSummary, URI detailsUrl) {
+  public TestResult(ZonedDateTime timestamp, IssueSummary vulnSummary, IssueSummary licenseSummary, URI detailsUrl) {
     this.timestamp = timestamp;
     this.vulnSummary = vulnSummary;
     this.licenseSummary = licenseSummary;

--- a/core/src/test/java/io/snyk/plugins/artifactory/model/MonitoredArtifactTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/model/MonitoredArtifactTest.java
@@ -1,5 +1,6 @@
 package io.snyk.plugins.artifactory.model;
 
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty;
 import io.snyk.plugins.artifactory.configuration.properties.FakeArtifactProperties;
 import io.snyk.sdk.model.Severity;
 import org.junit.jupiter.api.Test;
@@ -91,5 +92,21 @@ class MonitoredArtifactTest {
     Optional<MonitoredArtifact> retrievedArtifact = MonitoredArtifact.read(properties);
 
     assertTrue(retrievedArtifact.isEmpty());
+  }
+
+  @Test
+  void read_whenPropertiesMalformed() {
+    FakeArtifactProperties properties = new FakeArtifactProperties("electron");
+    new MonitoredArtifact("electron",
+      new TestResult(
+        IssueSummary.from(Stream.of()),
+        IssueSummary.from(Stream.of()),
+        URI.create("https://app.snyk.io/package/electron/1.0.0")
+      ),
+      new Ignores()
+    ).write(properties);
+    properties.set(TEST_TIMESTAMP, "not a valid timestamp");
+
+    assertTrue(MonitoredArtifact.read(properties).isEmpty());
   }
 }


### PR DESCRIPTION
Introduces a new param `snyk.scanner.extendTestDeadline.hours`. In case there is a Snyk request error when the next test is due, this parameter allows the plugin to use the previous test result when deciding whether to block access.