### PR TITLE
feat: add continuous testing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ After making changes to the plugin, repeat `mvn install` and extract the jar fil
 
 ```shell
 unzip -p distribution/target/artifactory-snyk-security-plugin-LOCAL-SNAPSHOT.zip plugins/lib/artifactory-snyk-security-core.jar > distribution/docker/etc/artifactory/plugins/lib/artifactory-snyk-security-core.jar
+unzip -p distribution/target/artifactory-snyk-security-plugin-LOCAL-SNAPSHOT.zip plugins/snykSecurityPlugin.groovy > distribution/docker/etc/artifactory/plugins/snykSecurityPlugin.groovy
 ```
 
 ## Inspecting plugin logs

--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.groovy
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.groovy
@@ -25,6 +25,16 @@ executions {
 }
 
 download {
+
+  afterRemoteDownload { Request request, RepoPath repoPath ->
+    try {
+      snykPlugin.handleAfterRemoteDownloadEvent(repoPath)
+    } catch (Exception e) {
+      log.error("An exception occurred during afterRemoteDownload, re-throwing it for Artifactory to handle. Message was: ${e.message}")
+      throw e
+    }
+  }
+
   beforeDownload { Request request, RepoPath repoPath ->
     try {
       snykPlugin.handleBeforeDownloadEvent(repoPath)
@@ -33,6 +43,7 @@ download {
       throw e
     }
   }
+
 }
 
 storage {

--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -44,13 +44,21 @@ snyk.api.organization=
 # Scanner Configuration
 # =====================
 
-# Scan result expiry. When the most recent scan was made within this time frame,
+# Decides whether the plugin should periodically refresh vulnerability data from Snyk
+# or filter access according to results obtained while the package was first requested.
+# Without the continuous mode, new vulnerabilities aren't reported for a package that has already been
+# allowed through the gatekeeper.
+# Accepts: "true", "false"
+# Default: "false"
+#snyk.scanner.test.continuously=false
+
+# Scan result expiry (continuous mode only). When the most recent scan was made within this time frame,
 # filtering respects the previous result. Beyond that time, a new Snyk Test request is made.
 # When this property is set to 0, the plugin triggers a test each time an artifact is accessed.
 # Default: 168 (1 week)
 #snyk.scanner.frequency.hours=168
 
-# How much to extend the scan result expiry when a Snyk Test request fails.
+# How much to extend the scan result expiry when a Snyk Test request fails (continuous mode only).
 # In case there is a Snyk request error when the next test is due,
 # this parameter allows the plugin to use the previous test result when deciding whether to block access.
 # Beyond this extended deadline, the result of filtering will depend on the snyk.scanner.block-on-api-failure param.

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -19,6 +19,7 @@ public enum PluginConfiguration implements Configuration {
   SCANNER_PACKAGE_TYPE_MAVEN("snyk.scanner.packageType.maven", "true"),
   SCANNER_PACKAGE_TYPE_NPM("snyk.scanner.packageType.npm", "true"),
   SCANNER_PACKAGE_TYPE_PYPI("snyk.scanner.packageType.pypi", "false"),
+  TEST_CONTINUOUSLY("snyk.scanner.test.continuously","false"),
   TEST_FREQUENCY_HOURS("snyk.scanner.frequency.hours", "168"),
   EXTEND_TEST_DEADLINE_HOURS("snyk.scanner.extendTestDeadline.hours", "24");
 

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
@@ -49,8 +49,8 @@ public class TestResult {
   public void write(ArtifactProperties properties) {
     LOG.info("Writing Snyk properties for package {}", detailsUrl);
     properties.set(TEST_TIMESTAMP, timestamp.toString());
-    properties.set(ISSUE_VULNERABILITIES, getVulnSummary().toString());
-    properties.set(ISSUE_LICENSES, getLicenseSummary().toString());
+    properties.set(ISSUE_VULNERABILITIES, vulnSummary.toString());
+    properties.set(ISSUE_LICENSES, licenseSummary.toString());
     properties.set(ISSUE_URL, detailsUrl.toString());
     properties.set(ISSUE_URL_PLAINTEXT, " " + detailsUrl);
   }
@@ -63,7 +63,7 @@ public class TestResult {
       .map(String::trim)
       .map(URI::create);
 
-    if(timestamp.isEmpty() || vulns.isEmpty() || licenses.isEmpty() || detailsUrl.isEmpty()) {
+    if (timestamp.isEmpty() || vulns.isEmpty() || licenses.isEmpty() || detailsUrl.isEmpty()) {
       return Optional.empty();
     }
     return Optional.of(new TestResult(

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ArtifactResolver.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ArtifactResolver.java
@@ -1,0 +1,12 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
+import io.snyk.plugins.artifactory.model.MonitoredArtifact;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public interface ArtifactResolver {
+
+  Optional<MonitoredArtifact> get(ArtifactProperties properties, Supplier<Optional<MonitoredArtifact>> fetch);
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ReadOnlyArtifactResolver.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ReadOnlyArtifactResolver.java
@@ -1,0 +1,15 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
+import io.snyk.plugins.artifactory.model.MonitoredArtifact;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class ReadOnlyArtifactResolver implements ArtifactResolver {
+
+  @Override
+  public Optional<MonitoredArtifact> get(ArtifactProperties properties, Supplier<Optional<MonitoredArtifact>> fetch) {
+    return MonitoredArtifact.read(properties);
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/ScannerModuleTest.java
@@ -108,7 +108,7 @@ public class ScannerModuleTest {
 
     // Using try-catch as assertThrows does not let us check the cause.
     try {
-      spyScanner.scanArtifact(repoPath);
+      spyScanner.testArtifact(repoPath);
       fail("Expected SnykAPIFailureException for timeout but no exception was thrown.");
     } catch (SnykAPIFailureException e) {
       Throwable cause = e.getCause();
@@ -129,7 +129,7 @@ public class ScannerModuleTest {
     when(repoPath.getPath()).thenReturn("myArtifact.tgz");
     when(repoPath.toString()).thenReturn("npm:minimist/-/minimist-1.2.6.tgz");
 
-    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    MonitoredArtifact result = spyScanner.testArtifact(repoPath).get();
 
     assertEquals(0, result.getTestResult().getVulnSummary().getTotalCount());
   }
@@ -146,7 +146,7 @@ public class ScannerModuleTest {
     when(repoPath.getPath()).thenReturn("myArtifact.tgz");
     when(repoPath.toString()).thenReturn("npm:lodash/-/lodash-4.17.15.tgz");
 
-    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    MonitoredArtifact result = spyScanner.testArtifact(repoPath).get();
     assertTrue(result.getTestResult().getVulnSummary().getTotalCount() > 0);
   }
 
@@ -162,7 +162,7 @@ public class ScannerModuleTest {
     RepoPath repoPath = testSetup.repoPath;
     when(repoPath.getPath()).thenReturn("myArtifact.jar");
 
-    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    MonitoredArtifact result = spyScanner.testArtifact(repoPath).get();
     assertEquals(0, result.getTestResult().getVulnSummary().getTotalCount());
   }
 
@@ -178,7 +178,7 @@ public class ScannerModuleTest {
     RepoPath repoPath = testSetup.repoPath;
     when(repoPath.getPath()).thenReturn("myArtifact.jar");
 
-    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    MonitoredArtifact result = spyScanner.testArtifact(repoPath).get();
     assertTrue(result.getTestResult().getVulnSummary().getTotalCount() > 0);
   }
 
@@ -193,7 +193,7 @@ public class ScannerModuleTest {
     RepoPath repoPath = testSetup.repoPath;
     when(repoPath.getPath()).thenReturn("myArtifact.whl");
 
-    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    MonitoredArtifact result = spyScanner.testArtifact(repoPath).get();
     assertEquals(0, result.getTestResult().getVulnSummary().getTotalCount());
   }
 
@@ -208,7 +208,7 @@ public class ScannerModuleTest {
     RepoPath repoPath = testSetup.repoPath;
     when(repoPath.getPath()).thenReturn("myArtifact.whl");
 
-    MonitoredArtifact result = spyScanner.resolveArtifact(repoPath);
+    MonitoredArtifact result = spyScanner.testArtifact(repoPath).get();
     assertEquals(6, result.getTestResult().getVulnSummary().getTotalCount());
   }
 }


### PR DESCRIPTION
This PR aligns the plugin closer with the original behaviour implemented for older versions of Artifactory.

The main contribution of this PR is introduction of a new lifecycle hook `afterRemoteDownload`. This hook is invoked by Artifactory whenever a package is fetched from external repositories. The plugin performs a Snyk Test at this stage. Access to the package is later controlled according to vulnerabilities discovered during the test, and in line with severity thresholds set in the plugin config.

This PR also brings in a new configuration parameter `snyk.scanner.test.continuously` which allows the plugin to periodically re-test packages. The parameter has two values:
- `false` (default). Never re-test packages, respect the result of the test performed when the package was originally downloaded. If the original test result is not known, access to the package is allowed.
- `true`. Re-test packages according to the `snyk.scanner.frequency.hours` parameter, or when the original test result is not known.