### PR TITLE
fix: refresh snyk details URLs

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
@@ -1,6 +1,8 @@
 package io.snyk.plugins.artifactory.model;
 
 import io.snyk.plugins.artifactory.configuration.properties.ArtifactProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -10,6 +12,8 @@ import java.util.Optional;
 import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.*;
 
 public class TestResult {
+  private static final Logger LOG = LoggerFactory.getLogger(TestResult.class);
+
   private final ZonedDateTime timestamp;
   private final IssueSummary vulnSummary;
   private final IssueSummary licenseSummary;
@@ -43,6 +47,7 @@ public class TestResult {
   }
 
   public void write(ArtifactProperties properties) {
+    LOG.info("Writing Snyk properties for package {}", detailsUrl);
     properties.set(TEST_TIMESTAMP, timestamp.toString());
     properties.set(ISSUE_VULNERABILITIES, getVulnSummary().toString());
     properties.set(ISSUE_LICENSES, getLicenseSummary().toString());

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/MavenScanner.java
@@ -9,11 +9,9 @@ import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 import org.slf4j.Logger;
 
-import java.net.URLEncoder;
 import java.util.Optional;
 
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
-import static java.nio.charset.StandardCharsets.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
 class MavenScanner implements PackageScanner {
@@ -29,7 +27,7 @@ class MavenScanner implements PackageScanner {
   }
 
   public static String getArtifactDetailsURL(String groupID, String artifactID, String artifactVersion) {
-    return "https://snyk.io/vuln/" + URLEncoder.encode("maven:" + groupID + ":" + artifactID + "@" + artifactVersion, UTF_8);
+    return SnykDetailsUrl.create("maven", groupID + ":" + artifactID, artifactVersion).toString();
   }
 
   public io.snyk.plugins.artifactory.model.TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/NpmScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/NpmScanner.java
@@ -42,7 +42,7 @@ class NpmScanner implements PackageScanner {
   }
 
   public static String getPackageDetailsURL(PackageURLDetails details) {
-    return "https://snyk.io/test/npm/" + details.name + "/" + details.version;
+    return SnykDetailsUrl.create("npm", details.name, details.version).toString();
   }
 
   public io.snyk.plugins.artifactory.model.TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PythonScanner.java
@@ -10,13 +10,11 @@ import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 import org.slf4j.Logger;
 
-import java.net.URLEncoder;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.snyk.plugins.artifactory.configuration.PluginConfiguration.API_ORGANIZATION;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.slf4j.LoggerFactory.getLogger;
 
 class PythonScanner implements PackageScanner {
@@ -56,7 +54,7 @@ class PythonScanner implements PackageScanner {
   }
 
   public static String getModuleDetailsURL(ModuleURLDetails details) {
-    return "https://snyk.io/vuln/" + URLEncoder.encode("pip:" + details.name + "@" + details.version, UTF_8);
+    return SnykDetailsUrl.create("pip", details.name, details.version).toString();
   }
 
   public io.snyk.plugins.artifactory.model.TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/SnykDetailsUrl.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/SnykDetailsUrl.java
@@ -1,0 +1,18 @@
+package io.snyk.plugins.artifactory.scanner;
+
+
+import java.net.URI;
+import java.net.URLEncoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class SnykDetailsUrl {
+
+  static URI create(String ecosystem, String packageName, String version) {
+    return URI.create(
+      String.format("https://security.snyk.io/package/%s/%s/%s", ecosystem,
+        URLEncoder.encode(packageName, UTF_8),
+        URLEncoder.encode(version, UTF_8))
+    );
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/MavenScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/MavenScannerTest.java
@@ -41,7 +41,7 @@ public class MavenScannerTest {
 
     TestResult result = scanner.scan(fileLayoutInfo, repoPath);
     assertTrue(result.getVulnSummary().getTotalCount() > 0);
-    assertEquals("https://snyk.io/vuln/maven%3Acom.fasterxml.jackson.core%3Ajackson-databind%402.9.8",
+    assertEquals("https://security.snyk.io/package/maven/com.fasterxml.jackson.core%3Ajackson-databind/2.9.8",
       result.getDetailsUrl().toString()
     );
   }
@@ -114,7 +114,7 @@ public class MavenScannerTest {
 
   @Test
   void getPackageDetailsURL_shouldEncodeNameAndVersion() {
-    var result = MavenScanner.getArtifactDetailsURL("com.fasterxml.jackson.core", "jackson-databind", "7.0.0-rc.4");
-    assertEquals("https://snyk.io/vuln/maven%3Acom.fasterxml.jackson.core%3Ajackson-databind%407.0.0-rc.4", result);
+    var result = MavenScanner.getArtifactDetailsURL("com.fasterxml.jackson.core", "jackson-databind", "2.12.0-rc1");
+    assertEquals("https://security.snyk.io/package/maven/com.fasterxml.jackson.core%3Ajackson-databind/2.12.0-rc1", result);
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/NpmScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/NpmScannerTest.java
@@ -38,7 +38,7 @@ public class NpmScannerTest {
 
     TestResult result = scanner.scan(fileLayoutInfo, repoPath);
     assertTrue(result.getVulnSummary().getTotalCount() > 0);
-    assertEquals("https://snyk.io/test/npm/lodash/4.17.15", result.getDetailsUrl().toString());
+    assertEquals("https://security.snyk.io/package/npm/lodash/4.17.15", result.getDetailsUrl().toString());
   }
 
   @Test
@@ -78,6 +78,6 @@ public class NpmScannerTest {
   void getPackageDetailsURL_shouldUseTestPage() {
     var details = new NpmScanner.PackageURLDetails("@babel/core", "7.0.0-rc.4");
     var result = NpmScanner.getPackageDetailsURL(details);
-    assertEquals("https://snyk.io/test/npm/@babel/core/7.0.0-rc.4", result);
+    assertEquals("https://security.snyk.io/package/npm/%40babel%2Fcore/7.0.0-rc.4", result);
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/PythonScannerTest.java
@@ -40,7 +40,7 @@ public class PythonScannerTest {
 
     TestResult result = scanner.scan(fileLayoutInfo, repoPath);
     assertEquals(6, result.getVulnSummary().getTotalCount());
-    assertEquals("https://snyk.io/vuln/pip%3Aurllib3%401.25.7", result.getDetailsUrl().toString());
+    assertEquals("https://security.snyk.io/package/pip/urllib3/1.25.7", result.getDetailsUrl().toString());
   }
 
   @Test
@@ -142,8 +142,8 @@ public class PythonScannerTest {
 
   @Test
   void getModuleDetailsURL_shouldEncodeNameAndVersion() {
-    var details = new PythonScanner.ModuleURLDetails("ws3", "0.0.1.post3");
+    var details = new PythonScanner.ModuleURLDetails("changedetection.io", "0.39.10.post1");
     var result = PythonScanner.getModuleDetailsURL(details);
-    assertEquals("https://snyk.io/vuln/pip%3Aws3%400.0.1.post3", result);
+    assertEquals("https://security.snyk.io/package/pip/changedetection.io/0.39.10.post1", result);
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/SnykDetailsUrlTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/SnykDetailsUrlTest.java
@@ -1,0 +1,17 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SnykDetailsUrlTest {
+
+  @Test
+  void encodesPackageNameAndVersion() {
+    URI uri = SnykDetailsUrl.create("maven", "owner:name", "v/1");
+
+    assertEquals("https://security.snyk.io/package/maven/owner%3Aname/v%2F1", uri.toString());
+  }
+}


### PR DESCRIPTION
This commit points the details URLs to the new pages (security.snyk.io) and introduces a log message to confirm that the URLs are being written to Artifactory properties.