### PR TITLE
fix: add a plain text Snyk URL property

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperty.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/properties/ArtifactProperty.java
@@ -3,6 +3,7 @@ package io.snyk.plugins.artifactory.configuration.properties;
 public enum ArtifactProperty {
   TEST_TIMESTAMP("snyk.test.timestamp"),
   ISSUE_URL("snyk.issue.url"),
+  ISSUE_URL_PLAINTEXT("snyk.issue.url.plaintext"),
   ISSUE_VULNERABILITIES("snyk.issue.vulnerabilities"),
   ISSUE_VULNERABILITIES_FORCE_DOWNLOAD("snyk.issue.vulnerabilities.forceDownload"),
   ISSUE_VULNERABILITIES_FORCE_DOWNLOAD_INFO("snyk.issue.vulnerabilities.forceDownload.info"),

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
@@ -51,14 +51,17 @@ public class TestResult {
     properties.set(TEST_TIMESTAMP, timestamp.toString());
     properties.set(ISSUE_VULNERABILITIES, getVulnSummary().toString());
     properties.set(ISSUE_LICENSES, getLicenseSummary().toString());
-    properties.set(ISSUE_URL, getDetailsUrl().toString());
+    properties.set(ISSUE_URL, detailsUrl.toString());
+    properties.set(ISSUE_URL_PLAINTEXT, " " + detailsUrl);
   }
 
   public static Optional<TestResult> read(ArtifactProperties properties) {
     Optional<ZonedDateTime> timestamp = properties.get(TEST_TIMESTAMP).map(ZonedDateTime::parse);
     Optional<IssueSummary> vulns = properties.get(ISSUE_VULNERABILITIES).flatMap(IssueSummary::parse);
     Optional<IssueSummary> licenses = properties.get(ISSUE_LICENSES).flatMap(IssueSummary::parse);
-    Optional<URI> detailsUrl = properties.get(ISSUE_URL).map(URI::create);
+    Optional<URI> detailsUrl = properties.get(ISSUE_URL)
+      .map(String::trim)
+      .map(URI::create);
 
     if(timestamp.isEmpty() || vulns.isEmpty() || licenses.isEmpty() || detailsUrl.isEmpty()) {
       return Optional.empty();


### PR DESCRIPTION
Some versions of Artifactory contain a bug: URL properties do not render.

When a whitespace gets introduced into a URL property, it's not treated as a URL any more and renders correctly:

https://github.com/user-attachments/assets/29ab7b62-a24c-46dd-b598-f5f9f10e7504

This PR brings a workaround for the bug by introducing a "plaintext" URL property which includes a whitespace:

![screenshot](https://github.com/user-attachments/assets/66d67e55-66b5-46e4-937b-96b378411476)

Users affected by the URL render bug will only see the plaintext property. Others will see both of them, one clickable and one plaintext.