### PR TITLE
feat: include snyk details URL in error messages

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,12 @@
       <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.26.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
@@ -58,7 +58,9 @@ public class PackageValidator {
     }
 
     LOG.debug("Package has {} with severity {} or higher: {}", issueType, threshold, artifact.getPath());
-    throw new CancelException(format("Artifact has %s with severity %s or higher: %s", issueType, threshold, artifact.getPath()), 403);
+    throw new CancelException(format("Artifact has %s with severity %s or higher: %s. Details: %s",
+      issueType, threshold, artifact.getPath(), artifact.getTestResult().getDetailsUrl()
+    ), 403);
   }
 
 }


### PR DESCRIPTION
Adding Snyk package URL to the error messages.

Also adding AssertJ as the vanilla JUnit assertion API is rather limited.