### PR TITLE
fix: respect NONE severity threshold

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
@@ -8,6 +8,8 @@ import org.artifactory.exception.CancelException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Optional;
+
 import static java.lang.String.format;
 
 public class PackageValidator {
@@ -45,8 +47,13 @@ public class PackageValidator {
     );
   }
 
-  private void validateIssues(IssueSummary summary, Severity threshold, boolean ignoreIssues, String issueType, MonitoredArtifact artifact) {
-    int countAboveThreshold = summary.getCountAtOrAbove(threshold);
+  private void validateIssues(IssueSummary summary, Optional<Severity> threshold, boolean ignoreIssues, String issueType, MonitoredArtifact artifact) {
+    if(threshold.isEmpty()) {
+      LOG.debug("No severity threshold set for {}", issueType);
+      return;
+    }
+
+    int countAboveThreshold = summary.getCountAtOrAbove(threshold.get());
     if (countAboveThreshold == 0) {
       LOG.debug("No {} with severity {} or higher: {}", issueType, threshold, artifact.getPath());
       return;

--- a/core/src/test/java/io/snyk/plugins/artifactory/model/ValidationSettingsTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/model/ValidationSettingsTest.java
@@ -1,0 +1,34 @@
+package io.snyk.plugins.artifactory.model;
+
+import io.snyk.sdk.model.Severity;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class ValidationSettingsTest {
+
+  @Test
+  void from_whenValidThresholds() {
+    ValidationSettings settings = ValidationSettings.from("high", "low");
+
+    assertThat(settings.getVulnSeverityThreshold()).contains(Severity.HIGH);
+    assertThat(settings.getLicenseSeverityThreshold()).contains(Severity.LOW);
+  }
+
+  @Test
+  void from_whenInvalidThresholds() {
+    assertThatThrownBy(() -> ValidationSettings.from("danger", "low"))
+      .hasMessageContaining("danger");
+  }
+
+  @Test
+  void from_whenNoThresholds() {
+    ValidationSettings settings = ValidationSettings.from("none", "none");
+
+    assertThat(settings.getVulnSeverityThreshold()).isEmpty();
+    assertThat(settings.getLicenseSeverityThreshold()).isEmpty();
+  }
+
+
+}


### PR DESCRIPTION
When severity threshold is set to `none`, download should be allowed regardless of the issues discovered.