### PR TITLE
feat: add support for CocoaPods and Nuget ecosystems

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -20,6 +20,8 @@ public enum PluginConfiguration implements Configuration {
   SCANNER_PACKAGE_TYPE_NPM("snyk.scanner.packageType.npm", "true"),
   SCANNER_PACKAGE_TYPE_PYPI("snyk.scanner.packageType.pypi", "false"),
   SCANNER_PACKAGE_TYPE_RUBYGEMS("snyk.scanner.packageType.gems", "false"),
+  SCANNER_PACKAGE_TYPE_NUGET("snyk.scanner.packageType.nuget", "false"),
+  SCANNER_PACKAGE_TYPE_COCOAPODS("snyk.scanner.packageType.cocoapods", "false"),
   TEST_CONTINUOUSLY("snyk.scanner.test.continuously","false"),
   TEST_FREQUENCY_HOURS("snyk.scanner.frequency.hours", "168"),
   EXTEND_TEST_DEADLINE_HOURS("snyk.scanner.extendTestDeadline.hours", "24");

--- a/core/src/main/java/io/snyk/plugins/artifactory/ecosystem/Ecosystem.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/ecosystem/Ecosystem.java
@@ -12,6 +12,8 @@ public enum Ecosystem {
   NPM(PluginConfiguration.SCANNER_PACKAGE_TYPE_NPM),
   PYPI(PluginConfiguration.SCANNER_PACKAGE_TYPE_PYPI),
   RUBYGEMS(PluginConfiguration.SCANNER_PACKAGE_TYPE_RUBYGEMS),
+  NUGET(PluginConfiguration.SCANNER_PACKAGE_TYPE_NUGET),
+  COCOAPODS(PluginConfiguration.SCANNER_PACKAGE_TYPE_COCOAPODS),
   ;
 
   private static final Logger LOG = LoggerFactory.getLogger(Ecosystem.class);
@@ -28,13 +30,25 @@ public enum Ecosystem {
 
   public static Optional<Ecosystem> match(String artifactoryPackageType, String artifactPath) {
     switch (artifactoryPackageType.toLowerCase()) {
-      case "maven": return Optional.of(MAVEN);
-      case "npm": return Optional.of(NPM);
-      case "pypi": return Optional.of(PYPI);
-      case "gems": return artifactPath.endsWith(".gem") ? Optional.of(RUBYGEMS) : Optional.empty();
+      case "maven":
+        return Optional.of(MAVEN);
+      case "npm":
+        return Optional.of(NPM);
+      case "pypi":
+        return Optional.of(PYPI);
+      case "gems":
+        return artifactPath.endsWith(".gem") ? Optional.of(RUBYGEMS) : Optional.empty();
+      case "nuget":
+        return artifactPath.endsWith(".nupkg") ? Optional.of(NUGET) : Optional.empty();
+      case "cocoapods":
+        return matchesCocoapods(artifactPath) ? Optional.of(COCOAPODS) : Optional.empty();
     }
 
     LOG.info("Unknown package type: {}", artifactoryPackageType);
     return Optional.empty();
+  }
+
+  private static boolean matchesCocoapods(String artifactPath) {
+    return artifactPath.endsWith(".tar.gz") || artifactPath.endsWith(".zip");
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/model/TestResult.java
@@ -47,7 +47,7 @@ public class TestResult {
   }
 
   public void write(ArtifactProperties properties) {
-    LOG.info("Writing Snyk properties for package {}", detailsUrl);
+    LOG.info("Writing Snyk properties for package {} - artifactory path {}", detailsUrl, properties.getArtifactPath());
     properties.set(TEST_TIMESTAMP, timestamp.toString());
     properties.set(ISSUE_VULNERABILITIES, vulnSummary.toString());
     properties.set(ISSUE_LICENSES, licenseSummary.toString());

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerResolver.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerResolver.java
@@ -3,6 +3,9 @@ package io.snyk.plugins.artifactory.scanner;
 import io.snyk.plugins.artifactory.configuration.ConfigurationModule;
 import io.snyk.plugins.artifactory.configuration.PluginConfiguration;
 import io.snyk.plugins.artifactory.ecosystem.Ecosystem;
+import io.snyk.plugins.artifactory.scanner.cocoapods.CocoapodsScanner;
+import io.snyk.plugins.artifactory.scanner.nuget.NugetScanner;
+import io.snyk.plugins.artifactory.scanner.purl.PurlScanner;
 import io.snyk.plugins.artifactory.scanner.rubygems.RubyGemsScanner;
 import io.snyk.sdk.api.SnykClient;
 import org.slf4j.Logger;
@@ -48,11 +51,14 @@ public class ScannerResolver {
 
   public static ScannerResolver setup(ConfigurationModule configurationModule, SnykClient snykClient) {
     String orgId = configurationModule.getProperty(API_ORGANIZATION);
+    PurlScanner purlScanner = new PurlScanner(snykClient, orgId);
     return new ScannerResolver(configurationModule::getPropertyOrDefault)
       .register(Ecosystem.MAVEN, new MavenScanner(configurationModule, snykClient))
       .register(Ecosystem.NPM, new NpmScanner(configurationModule, snykClient))
       .register(Ecosystem.PYPI, new PythonScanner(configurationModule, snykClient))
-      .register(Ecosystem.RUBYGEMS, new RubyGemsScanner(snykClient, orgId))
+      .register(Ecosystem.RUBYGEMS, new RubyGemsScanner(purlScanner))
+      .register(Ecosystem.NUGET, new NugetScanner(purlScanner))
+      .register(Ecosystem.COCOAPODS, new CocoapodsScanner(purlScanner))
       ;
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsPackage.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsPackage.java
@@ -1,0 +1,46 @@
+package io.snyk.plugins.artifactory.scanner.cocoapods;
+
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class CocoapodsPackage {
+  private static final Logger LOG = getLogger(CocoapodsPackage.class);
+  private final String name;
+  private final String version;
+
+  public CocoapodsPackage(String name, String version) {
+    this.name = name;
+    this.version = version;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public static Optional<CocoapodsPackage> parse(
+      String artifactoryPackageName
+  ) {
+    if (artifactoryPackageName == null) {
+      LOG.warn("Unexpected package name: null");
+      return Optional.empty();
+    }
+
+    String[] nameVersion = artifactoryPackageName.replace(".tar.gz", "")
+        .replaceFirst("(?s)-(?!.*?-)", "!")
+        .split("!");
+
+    if (nameVersion.length != 2) {
+      LOG.warn("Unexpected Cocoapods package name: {}", artifactoryPackageName);
+      return Optional.empty();
+    }
+
+    return Optional.of(new CocoapodsPackage(nameVersion[0], nameVersion[1]));
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsScanner.java
@@ -1,4 +1,4 @@
-package io.snyk.plugins.artifactory.scanner.rubygems;
+package io.snyk.plugins.artifactory.scanner.cocoapods;
 
 import io.snyk.plugins.artifactory.exception.CannotScanException;
 import io.snyk.plugins.artifactory.model.TestResult;
@@ -7,21 +7,27 @@ import io.snyk.plugins.artifactory.scanner.SnykDetailsUrl;
 import io.snyk.plugins.artifactory.scanner.purl.PurlScanner;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
+import org.slf4j.Logger;
 
-public class RubyGemsScanner implements PackageScanner {
+import static org.slf4j.LoggerFactory.getLogger;
 
+public class CocoapodsScanner implements PackageScanner {
+
+  private static final Logger LOG = getLogger(CocoapodsScanner.class);
   private final PurlScanner purlScanner;
 
-  public RubyGemsScanner(PurlScanner purlScanner) {
+  public CocoapodsScanner(PurlScanner purlScanner) {
     this.purlScanner = purlScanner;
   }
 
   @Override
   public TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
-    RubyGemsPackage pckg = RubyGemsPackage.parse(repoPath.getName())
-      .orElseThrow(() -> new CannotScanException("Unexpected Ruby Gems package name: " + repoPath.getName()));
+    LOG.debug("Cocoapods: repoPath.getName() {}", repoPath.getName());
 
-    String purl = "pkg:gem/" + pckg.getName() + "@" + pckg.getVersion();
+    CocoapodsPackage pckg = CocoapodsPackage.parse(repoPath.getName())
+      .orElseThrow(() -> new CannotScanException("Unexpected Cocoapods package name" + repoPath.getName()));
+
+    String purl = "pkg:cocoapods/" + pckg.getName() + "@" + pckg.getVersion();
 
     String packageDetailsUrl = getModuleDetailsURL(pckg.getName(), pckg.getVersion());
 
@@ -29,6 +35,7 @@ public class RubyGemsScanner implements PackageScanner {
   }
 
   public static String getModuleDetailsURL(String name, String version) {
-    return SnykDetailsUrl.create("rubygems", name, version).toString();
+    return SnykDetailsUrl.create("cocoapods", name, version).toString();
   }
 }
+

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/nuget/NugetPackage.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/nuget/NugetPackage.java
@@ -1,0 +1,47 @@
+package io.snyk.plugins.artifactory.scanner.nuget;
+
+
+import org.slf4j.Logger;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class NugetPackage {
+  private static final Logger LOG = getLogger(NugetPackage.class);
+  private final String name;
+  private final String version;
+
+  public NugetPackage(String name, String version) {
+    this.name = name;
+    this.version = version;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public static Optional<NugetPackage> parse(String artifactoryPackageName) {
+    if (artifactoryPackageName == null) {
+      LOG.warn("Unexpected Nuget package name: null");
+      return Optional.empty();
+    }
+
+    Pattern pattern = Pattern.compile("\\.([0-9]+\\..*)\\.nupkg");
+    Matcher matcher = pattern.matcher(artifactoryPackageName);
+    if (!matcher.find()) {
+      LOG.warn("Unexpected Nuget package name: {}", artifactoryPackageName);
+      return Optional.empty();
+    }
+    String name = artifactoryPackageName.substring(0, matcher.start());
+    String version = matcher.group(1);
+
+    return Optional.of(new NugetPackage(name, version));
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/nuget/NugetScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/nuget/NugetScanner.java
@@ -1,4 +1,4 @@
-package io.snyk.plugins.artifactory.scanner.rubygems;
+package io.snyk.plugins.artifactory.scanner.nuget;
 
 import io.snyk.plugins.artifactory.exception.CannotScanException;
 import io.snyk.plugins.artifactory.model.TestResult;
@@ -8,20 +8,20 @@ import io.snyk.plugins.artifactory.scanner.purl.PurlScanner;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.repo.RepoPath;
 
-public class RubyGemsScanner implements PackageScanner {
+public class NugetScanner implements PackageScanner {
 
   private final PurlScanner purlScanner;
 
-  public RubyGemsScanner(PurlScanner purlScanner) {
+  public NugetScanner(PurlScanner purlScanner) {
     this.purlScanner = purlScanner;
   }
 
   @Override
   public TestResult scan(FileLayoutInfo fileLayoutInfo, RepoPath repoPath) {
-    RubyGemsPackage pckg = RubyGemsPackage.parse(repoPath.getName())
-      .orElseThrow(() -> new CannotScanException("Unexpected Ruby Gems package name: " + repoPath.getName()));
+    NugetPackage pckg = NugetPackage.parse(repoPath.getName())
+      .orElseThrow(() -> new CannotScanException("Unexpected Nuget package name: " + repoPath.getName()));
 
-    String purl = "pkg:gem/" + pckg.getName() + "@" + pckg.getVersion();
+    String purl = "pkg:nuget/" + pckg.getName() + "@" + pckg.getVersion();
 
     String packageDetailsUrl = getModuleDetailsURL(pckg.getName(), pckg.getVersion());
 
@@ -29,6 +29,6 @@ public class RubyGemsScanner implements PackageScanner {
   }
 
   public static String getModuleDetailsURL(String name, String version) {
-    return SnykDetailsUrl.create("rubygems", name, version).toString();
+    return SnykDetailsUrl.create("nuget", name, version).toString();
   }
 }

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/purl/PurlScanner.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/purl/PurlScanner.java
@@ -1,0 +1,50 @@
+package io.snyk.plugins.artifactory.scanner.purl;
+
+import io.snyk.plugins.artifactory.exception.SnykAPIFailureException;
+import io.snyk.plugins.artifactory.model.TestResult;
+import io.snyk.plugins.artifactory.scanner.TestResultConverter;
+import io.snyk.sdk.api.SnykClient;
+import io.snyk.sdk.api.SnykResult;
+import io.snyk.sdk.model.purl.PurlIssues;
+import org.slf4j.Logger;
+
+import java.net.URLEncoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class PurlScanner {
+
+  private static final Logger LOG = getLogger(PurlScanner.class);
+
+  private final SnykClient snykClient;
+  private final String orgId;
+
+  public PurlScanner(SnykClient snykClient, String orgId) {
+    this.snykClient = snykClient;
+    this.orgId = orgId;
+  }
+
+  public TestResult scan(String purl, String packageDetailsUrl) {
+    SnykResult<PurlIssues> result;
+    try {
+      LOG.debug("Running Snyk test: {}", packageDetailsUrl);
+      result = snykClient.get(PurlIssues.class, request ->
+        request
+          .withPath(String.format("rest/orgs/%s/packages/%s/issues",
+            URLEncoder.encode(orgId, UTF_8),
+            URLEncoder.encode(purl, UTF_8))
+          )
+          .withQueryParam("version", "2024-10-15")
+      );
+    } catch (Exception e) {
+      throw new SnykAPIFailureException(e);
+    }
+
+    PurlIssues testResult = result.get().orElseThrow(() -> new SnykAPIFailureException(result));
+    testResult.packageDetailsUrl = packageDetailsUrl;
+
+    return TestResultConverter.convert(testResult);
+  }
+
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/rubygems/RubyGemsPackage.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/rubygems/RubyGemsPackage.java
@@ -1,10 +1,15 @@
 package io.snyk.plugins.artifactory.scanner.rubygems;
 
+import org.slf4j.Logger;
+
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class RubyGemsPackage {
+  private static final Logger LOG = getLogger(RubyGemsPackage.class);
   private final String name;
   private final String version;
 
@@ -23,11 +28,13 @@ public class RubyGemsPackage {
 
   public static Optional<RubyGemsPackage> parse(String artifactoryPackageName) {
     if(artifactoryPackageName == null) {
+      LOG.warn("Unexpected Gems package name: null");
       return Optional.empty();
     }
     Pattern pattern = Pattern.compile("(.*)-([^-]+)\\.gem", Pattern.CASE_INSENSITIVE);
     Matcher matcher = pattern.matcher(artifactoryPackageName);
     if(!matcher.matches()) {
+      LOG.warn("Unexpected Gems package name: {}", artifactoryPackageName);
       return Optional.empty();
     }
     return Optional.of(new RubyGemsPackage(matcher.group(1), matcher.group(2)));

--- a/core/src/test/java/io/snyk/plugins/artifactory/ecosystem/EcosystemTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/ecosystem/EcosystemTest.java
@@ -2,22 +2,40 @@ package io.snyk.plugins.artifactory.ecosystem;
 
 import org.junit.jupiter.api.Test;
 
-import static io.snyk.plugins.artifactory.ecosystem.Ecosystem.match;
+import static io.snyk.plugins.artifactory.ecosystem.Ecosystem.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class EcosystemTest {
 
   @Test
   void ecosystemByPackageType() {
-    assertThat(match("maven", "")).contains(Ecosystem.MAVEN);
-    assertThat(match("npm", "")).contains(Ecosystem.NPM);
-    assertThat(match("pypi", "")).contains(Ecosystem.PYPI);
-    assertThat(match("gems", "gems/rack-protection-4.1.1.gem")).contains(Ecosystem.RUBYGEMS);
-    assertThat(match("nuget", "")).isEmpty();
+    assertThat(match("maven", "")).contains(MAVEN);
+    assertThat(match("npm", "")).contains(NPM);
+    assertThat(match("pypi", "")).contains(PYPI);
+    assertThat(match("gems", "gems/rack-protection-4.1.1.gem")).contains(RUBYGEMS);
+    assertThat(match("nuget", "/newtonsoft.json.13.0.2.nupkg")).contains(NUGET);
+    assertThat(match("cocoapods", "/Alamofire/archive/5.10.1.tar.gz")).contains(COCOAPODS);
+    assertThat(match("unknown", "")).isEmpty();
+  }
+
+  @Test
+  void cocoapods_noMatchWhenNoExtension() {
+    assertThat(match("cocoapods", "Alamofire.git/info/refs?service=git-upload-pack"))
+      .isEmpty();
+  }
+
+  @Test
+  void cocoapods_matchWhenZipExtension() {
+    assertThat(match("cocoapods", "package.zip")).contains(COCOAPODS);
   }
 
   @Test
   void gems_noMatchWhenNoExtension() {
     assertThat(match("gems", "gems/rack-protection")).isEmpty();
+  }
+
+  @Test
+  void nuget_noMatchWhenNoExtension() {
+    assertThat(match("nuget", "newtonsoft.json/13.0.2.json")).isEmpty();
   }
 }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsPackageTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsPackageTest.java
@@ -1,0 +1,31 @@
+package io.snyk.plugins.artifactory.scanner.cocoapods;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CocoapodsPackageTest {
+
+  @Test
+  void parse() {
+    Optional<CocoapodsPackage> pckg = CocoapodsPackage.parse(
+        "Bolts-ObjC-1.9.1.tar.gz"
+    );
+
+    assertThat(pckg).isNotEmpty();
+    assertThat(pckg.get().getName()).isEqualTo("Bolts-ObjC");
+    assertThat(pckg.get().getVersion()).isEqualTo("1.9.1");
+  }
+
+  @Test
+  void parse_unexpectedPackageName() {
+    assertThat(CocoapodsPackage.parse("3.5.1.tar.gz")).isEmpty();
+  }
+
+  @Test
+  void parse_null() {
+    assertThat(CocoapodsPackage.parse(null)).isEmpty();
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsScannerTest.java
@@ -1,0 +1,48 @@
+package io.snyk.plugins.artifactory.scanner.cocoapods;
+
+import io.snyk.plugins.artifactory.model.TestResult;
+import io.snyk.plugins.artifactory.scanner.purl.PurlScanner;
+import io.snyk.plugins.artifactory.util.SnykConfigForTests;
+import io.snyk.sdk.SnykConfig;
+import io.snyk.sdk.api.SnykClient;
+import io.snyk.sdk.model.Severity;
+import org.artifactory.fs.FileLayoutInfo;
+import org.artifactory.repo.RepoPath;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CocoapodsScannerTest {
+  CocoapodsScanner scanner;
+
+  RepoPath repoPath;
+  FileLayoutInfo fileLayoutInfo;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    SnykConfig config = SnykConfigForTests.withDefaults();
+
+    SnykClient snykClient = new SnykClient(config);
+    scanner = new CocoapodsScanner(new PurlScanner(snykClient, org));
+
+    repoPath = mock(RepoPath.class);
+    fileLayoutInfo = mock(FileLayoutInfo.class);
+  }
+
+  @Test
+  void whenAValidPackage() {
+    when(repoPath.getName()).thenReturn("OpenSSL-1.0.2.tar.gz");
+    when(repoPath.getPath()).thenReturn("OpenSSL/OpenSSL/tags/1.0.2/OpenSSL-1.0.2.tar.gz");
+
+    TestResult result = scanner.scan(fileLayoutInfo, repoPath);
+    assertThat(result.getVulnSummary().getCountAtOrAbove(Severity.MEDIUM)).isGreaterThanOrEqualTo(63);
+    assertThat(result.getDetailsUrl().toString()).isEqualTo("https://security.snyk.io/package/cocoapods/OpenSSL/1.0.2");
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/nuget/NugetPackageTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/nuget/NugetPackageTest.java
@@ -1,0 +1,29 @@
+package io.snyk.plugins.artifactory.scanner.nuget;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NugetPackageTest {
+
+  @Test
+  void parse() {
+    Optional<NugetPackage> pkg = NugetPackage.parse("newtonsoft.json.13.10.2.nupkg");
+
+    assertThat(pkg).isNotEmpty();
+    assertThat(pkg.get().getName()).isEqualTo("newtonsoft.json");
+    assertThat(pkg.get().getVersion()).isEqualTo("13.10.2");
+  }
+
+  @Test
+  void parse_unexpectedInput() {
+    assertThat(NugetPackage.parse("newtonsoft.json.nupkg")).isEmpty();
+  }
+
+  @Test
+  void parse_null() {
+    assertThat(NugetPackage.parse(null)).isEmpty();
+  }
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/nuget/NugetScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/nuget/NugetScannerTest.java
@@ -1,0 +1,49 @@
+package io.snyk.plugins.artifactory.scanner.nuget;
+
+import io.snyk.plugins.artifactory.model.TestResult;
+import io.snyk.plugins.artifactory.scanner.purl.PurlScanner;
+import io.snyk.plugins.artifactory.util.SnykConfigForTests;
+import io.snyk.sdk.SnykConfig;
+import io.snyk.sdk.api.SnykClient;
+import io.snyk.sdk.model.Severity;
+import org.artifactory.fs.FileLayoutInfo;
+import org.artifactory.repo.RepoPath;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NugetScannerTest {
+
+  NugetScanner scanner;
+
+  RepoPath repoPath;
+  FileLayoutInfo fileLayoutInfo;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    String org = System.getenv("TEST_SNYK_ORG");
+    Assertions.assertNotNull(org, "must not be null for test");
+
+    SnykConfig config = SnykConfigForTests.withDefaults();
+
+    SnykClient snykClient = new SnykClient(config);
+    scanner = new NugetScanner(new PurlScanner(snykClient, org));
+
+    repoPath = mock(RepoPath.class);
+    fileLayoutInfo = mock(FileLayoutInfo.class);
+  }
+
+  @Test
+  void whenAValidNugetPackage() {
+    when(repoPath.getName()).thenReturn("newtonsoft.json.13.0.0.nupkg");
+
+    TestResult result = scanner.scan(fileLayoutInfo, repoPath);
+    assertThat(result.getVulnSummary().getCountAtOrAbove(Severity.MEDIUM)).isGreaterThanOrEqualTo(1);
+    assertThat(result.getDetailsUrl().toString()).isEqualTo("https://security.snyk.io/package/nuget/newtonsoft.json/13.0.0");
+  }
+
+}

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/rubygems/RubyGemsScannerTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/rubygems/RubyGemsScannerTest.java
@@ -2,6 +2,7 @@ package io.snyk.plugins.artifactory.scanner.rubygems;
 
 import io.snyk.plugins.artifactory.exception.CannotScanException;
 import io.snyk.plugins.artifactory.model.TestResult;
+import io.snyk.plugins.artifactory.scanner.purl.PurlScanner;
 import io.snyk.plugins.artifactory.util.SnykConfigForTests;
 import io.snyk.sdk.SnykConfig;
 import io.snyk.sdk.api.SnykClient;
@@ -31,7 +32,7 @@ class RubyGemsScannerTest {
     SnykConfig config = SnykConfigForTests.withDefaults();
 
     SnykClient snykClient = new SnykClient(config);
-    scanner = new RubyGemsScanner(snykClient, org);
+    scanner = new RubyGemsScanner(new PurlScanner(snykClient, org));
 
     repoPath = mock(RepoPath.class);
     fileLayoutInfo = mock(FileLayoutInfo.class);


### PR DESCRIPTION
Similar to the Gems scanner, CocoaPods and Nuget are powered by Snyk's PURL test API. Disabled by default so these new ecosystems won't be scanned unless explicitly opted-in.