### PR TITLE
feat: switch first lifecycle hook to afterCreate

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.groovy
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.groovy
@@ -26,15 +26,6 @@ executions {
 
 download {
 
-  afterRemoteDownload { Request request, RepoPath repoPath ->
-    try {
-      snykPlugin.handleAfterRemoteDownloadEvent(repoPath)
-    } catch (Exception e) {
-      log.error("An exception occurred during afterRemoteDownload, re-throwing it for Artifactory to handle. Message was: ${e.message}")
-      throw e
-    }
-  }
-
   beforeDownload { Request request, RepoPath repoPath ->
     try {
       snykPlugin.handleBeforeDownloadEvent(repoPath)
@@ -47,6 +38,16 @@ download {
 }
 
 storage {
+
+  afterCreate { ItemInfo itemInfo ->
+    try {
+      snykPlugin.handleAfterCreate(itemInfo.repoPath)
+    } catch (Exception e) {
+      log.error("An exception occurred during afterCreate, re-throwing it for Artifactory to handle. Message was: ${e.message}")
+      throw e
+    }
+  }
+
   afterPropertyCreate { ItemInfo itemInfo, String propertyName, String[] propertyValues ->
     try {
       snykPlugin.handleAfterPropertyCreateEvent(security.currentUser(), itemInfo, propertyName, propertyValues)

--- a/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/SnykPlugin.java
@@ -93,10 +93,10 @@ public class SnykPlugin {
    * Invoked once when an artifact is first fetched from an external repository.
    * Runs Snyk test and persists the result in properties.
    * <p>
-   * Extension point: {@code download.afterRemoteDownload}.
+   * Extension point: {@code storage.afterCreate}.
    */
-  public void handleAfterRemoteDownloadEvent(RepoPath repoPath) {
-    LOG.debug("Handle 'afterRemoteDownload' event for: {}", repoPath);
+  public void handleAfterCreate(RepoPath repoPath) {
+    LOG.debug("Handle 'afterCreate' event for: {}", repoPath);
 
     try {
       scannerModule.testArtifact(repoPath);


### PR DESCRIPTION
Switching the hook which gates artifact downloads from `afterRemoteDownload` to `afterCreate`.

For some ecosystems, e.g. Python and Cocoapods, properties would fail to write during the `afterRemoteDownload`. This would manifest with the following error message in Artifactory logs:

```
Cannot add properties for <repository path> Item not found.
```

The `afterCreate` hook is also attached to initial downloads of artifacts, and properties are successfully created in this context across all ecosystems supported by this plugin.