### PR TITLE
fix: strip off version prefix when parsing CocoaPods paths

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsPackage.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsPackage.java
@@ -33,8 +33,7 @@ public class CocoapodsPackage {
     }
 
     String[] nameVersion = artifactoryPackageName.replace(".tar.gz", "")
-        .replaceFirst("(?s)-(?!.*?-)", "!")
-        .split("!");
+        .split("(?s)-[a-zA-Z]*(?!.*?-)");
 
     if (nameVersion.length != 2) {
       LOG.warn("Unexpected Cocoapods package name: {}", artifactoryPackageName);

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsPackageTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/cocoapods/CocoapodsPackageTest.java
@@ -20,6 +20,17 @@ class CocoapodsPackageTest {
   }
 
   @Test
+  void parse_whenVersionNumberHasVPrefix() {
+    Optional<CocoapodsPackage> pckg = CocoapodsPackage.parse(
+        "libwebp-v1.3.0.tar.gz"
+    );
+
+    assertThat(pckg).isNotEmpty();
+    assertThat(pckg.get().getName()).isEqualTo("libwebp");
+    assertThat(pckg.get().getVersion()).isEqualTo("1.3.0");
+  }
+
+  @Test
   void parse_unexpectedPackageName() {
     assertThat(CocoapodsPackage.parse("3.5.1.tar.gz")).isEmpty();
   }


### PR DESCRIPTION
For CocoaPods artifacts coming with a `v` prefix in the artifactory path, e.g. `libwebp-v1.3.0.tar.gz`, the parsed version number should skip the prefix i.e. it should be `1.3.0` and not `v1.3.0`.