### PR TITLE
feat: Add handling for forceDownload when checking the lastModifiedDate

### DIFF
--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/PackageValidator.java
@@ -31,6 +31,12 @@ public class PackageValidator {
   }
 
   private void validateLastModifiedDelay(MonitoredArtifact artifact) {
+    boolean ignoreLastModifiedDelay = artifact.getIgnores().shouldIgnoreVulnIssues();
+    if (ignoreLastModifiedDelay) {
+      LOG.debug("Last modified date delay is ignored for {}", artifact.getPath());
+      return;
+    }
+
     Integer delayDays = settings.getLastModifiedDelayDays().get();
     if (delayDays == null || delayDays <= 0) {
       LOG.debug("Last modifed date delay is disabled ({} days)", delayDays);


### PR DESCRIPTION
Change validateLastModifiedDate() to respect snyk.issue.vulnerabilities.forceDownload.

This is a quick fix for a customer with an immediate need. I plan to implement a dedicated configuration to control this behavior.