### PR TITLE
feat: Add allowlist for last modified date

### DIFF
--- a/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
+++ b/core/src/main/groovy/io/snyk/plugins/artifactory/snykSecurityPlugin.properties
@@ -72,9 +72,16 @@ snyk.api.organization=
 # Default: 0
 #snyk.scanner.lastModified.days=0
 
-# If remoteOnly is set to true, only check lastModified for packages contained in remote repositories.
-# Default: true
-#snyk.scanner.lastModified.remoteOnly=true
+# Comma-separated substrings matched against the repository key. If the key contains any of these substrings,
+# the last-modified delay check is not applied for that repository. When empty, last-modified applies to all
+# repositories (unless legacy remoteOnly below is used). Example: "-local,cache,virtual"
+# Default: (empty)
+#snyk.scanner.lastModified.allowlist=
+
+# Deprecated: when snyk.scanner.lastModified.allowlist is empty and this is true, only remote repositories
+# receive the last-modified delay check. Ignored when allowlist is non-empty. Prefer allowlist.
+# Default: false
+#snyk.scanner.lastModified.remoteOnly=false
 
 # By default, if Snyk API fails while scanning an artifact for any reason, the download will be allowed.
 # When a download is blocked, artifact property "snyk.block.reason" records the message (see README).

--- a/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/configuration/PluginConfiguration.java
@@ -34,7 +34,12 @@ public enum PluginConfiguration implements Configuration {
   TEST_FREQUENCY_HOURS("snyk.scanner.frequency.hours", "168"),
   EXTEND_TEST_DEADLINE_HOURS("snyk.scanner.extendTestDeadline.hours", "24"),
   SCANNER_LAST_MODIFIED_DELAY_DAYS("snyk.scanner.lastModified.days", "0"),
-  SCANNER_LAST_MODIFIED_CHECK_ONLY_REMOTE("snyk.scanner.lastModified.remoteOnly", "true");
+  SCANNER_LAST_MODIFIED_ALLOWLIST("snyk.scanner.lastModified.allowlist", ""),
+  /**
+   * @deprecated Use {@link #SCANNER_LAST_MODIFIED_ALLOWLIST} to control which repository keys skip the last-modified delay check.
+   */
+  @Deprecated
+  SCANNER_LAST_MODIFIED_CHECK_ONLY_REMOTE("snyk.scanner.lastModified.remoteOnly", "false");
 
   private final String propertyKey;
   private final String defaultValue;

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/LastModifiedRepositoryPolicy.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/LastModifiedRepositoryPolicy.java
@@ -1,0 +1,37 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parses {@link io.snyk.plugins.artifactory.configuration.PluginConfiguration#SCANNER_LAST_MODIFIED_ALLOWLIST}
+ * and decides whether a repository key matches any allowlisted substring.
+ */
+final class LastModifiedRepositoryPolicy {
+
+  private LastModifiedRepositoryPolicy() {}
+
+  static List<String> parseAllowlist(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return List.of();
+    }
+    List<String> out = new ArrayList<>();
+    for (String segment : raw.split(",")) {
+      String t = segment.trim();
+      if (!t.isEmpty()) {
+        out.add(t);
+      }
+    }
+    return out.isEmpty() ? List.of() : Collections.unmodifiableList(out);
+  }
+
+  static boolean repoKeyMatchesAllowlist(String repoKey, List<String> substrings) {
+    for (String s : substrings) {
+      if (repoKey.contains(s)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
+++ b/core/src/main/java/io/snyk/plugins/artifactory/scanner/ScannerModule.java
@@ -24,13 +24,17 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.snyk.plugins.artifactory.configuration.properties.ArtifactProperty.BLOCK_REASON;
 import static java.util.Objects.requireNonNull;
 
 public class ScannerModule {
   private static final Logger LOG = LoggerFactory.getLogger(ScannerModule.class);
+  private static final AtomicBoolean LOGGED_DEPRECATED_REMOTE_ONLY = new AtomicBoolean(false);
+  private static final AtomicBoolean LOGGED_REMOTE_ONLY_IGNORED_WITH_ALLOWLIST = new AtomicBoolean(false);
   private final ConfigurationModule configurationModule;
   private final Repositories repositories;
   private final EcosystemResolver ecosystemResolver;
@@ -125,15 +129,10 @@ public class ScannerModule {
   }
 
   private Instant getLastModifiedDate(RepoPath repoPath) {
-    // Only apply lastModifiedDate to packages from remote repositories.
-    if(lastModifiedDateRemoteOnly()) {
-      LOG.debug("Last modified date applied to only remote repositories.");
-      if (!isRemoteRepository(repoPath)) {
-        LOG.debug("Provided repository is not a remote repository, skipping last modified date check for {}", repoPath);
-        return null;
-      }
+    if (shouldSkipLastModifiedForRepository(repoPath)) {
+      return null;
     }
-    
+
     try {
       ItemInfo itemInfo = repositories.getItemInfo(repoPath);
       if (itemInfo != null) {
@@ -149,6 +148,45 @@ public class ScannerModule {
     return null;
   }
 
+  /**
+   * When {@link PluginConfiguration#SCANNER_LAST_MODIFIED_ALLOWLIST} is non-empty, repository keys containing any
+   * configured substring skip the last-modified delay check. When the allowlist is empty and legacy
+   * {@link PluginConfiguration#SCANNER_LAST_MODIFIED_CHECK_ONLY_REMOTE} is true, only remote repositories keep the check.
+   */
+  private boolean shouldSkipLastModifiedForRepository(RepoPath repoPath) {
+    String allowlistRaw = configurationModule.getPropertyOrDefault(PluginConfiguration.SCANNER_LAST_MODIFIED_ALLOWLIST);
+    List<String> allowlist = LastModifiedRepositoryPolicy.parseAllowlist(allowlistRaw);
+    String repoKey = repoPath.getRepoKey();
+
+    if (!allowlist.isEmpty()) {
+      if (lastModifiedDateRemoteOnly() && LOGGED_REMOTE_ONLY_IGNORED_WITH_ALLOWLIST.compareAndSet(false, true)) {
+        LOG.warn(
+          "snyk.scanner.lastModified.remoteOnly is set but ignored because snyk.scanner.lastModified.allowlist is configured; remove remoteOnly."
+        );
+      }
+      if (LastModifiedRepositoryPolicy.repoKeyMatchesAllowlist(repoKey, allowlist)) {
+        LOG.debug("Repository key matches last-modified allowlist, skipping last modified date for {}", repoPath);
+        return true;
+      }
+      return false;
+    }
+
+    if (lastModifiedDateRemoteOnly()) {
+      if (LOGGED_DEPRECATED_REMOTE_ONLY.compareAndSet(false, true)) {
+        LOG.warn(
+          "snyk.scanner.lastModified.remoteOnly is deprecated; use snyk.scanner.lastModified.allowlist to skip the last-modified check for specific repository keys."
+        );
+      }
+      if (!isRemoteRepository(repoPath)) {
+        LOG.debug("Legacy remoteOnly: repository is not remote, skipping last modified date for {}", repoPath);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /** Used only when {@link PluginConfiguration#SCANNER_LAST_MODIFIED_CHECK_ONLY_REMOTE} is true and the allowlist is empty. */
   private boolean isRemoteRepository(RepoPath repoPath) {
     String repoKey = repoPath.getRepoKey();
     RepositoryConfiguration repoConfig = repositories.getRepositoryConfiguration(repoKey);
@@ -163,6 +201,7 @@ public class ScannerModule {
     return configurationModule.getPropertyOrDefault(PluginConfiguration.TEST_CONTINUOUSLY).equals("true");
   }
 
+  @SuppressWarnings("deprecation")
   private boolean lastModifiedDateRemoteOnly() {
     return configurationModule.getPropertyOrDefault(PluginConfiguration.SCANNER_LAST_MODIFIED_CHECK_ONLY_REMOTE).equals("true");
   }

--- a/core/src/test/java/io/snyk/plugins/artifactory/scanner/LastModifiedRepositoryPolicyTest.java
+++ b/core/src/test/java/io/snyk/plugins/artifactory/scanner/LastModifiedRepositoryPolicyTest.java
@@ -1,0 +1,40 @@
+package io.snyk.plugins.artifactory.scanner;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LastModifiedRepositoryPolicyTest {
+
+  @Test
+  void parseAllowlist_nullOrBlank_returnsEmpty() {
+    assertTrue(LastModifiedRepositoryPolicy.parseAllowlist(null).isEmpty());
+    assertTrue(LastModifiedRepositoryPolicy.parseAllowlist("").isEmpty());
+    assertTrue(LastModifiedRepositoryPolicy.parseAllowlist("   ").isEmpty());
+    assertTrue(LastModifiedRepositoryPolicy.parseAllowlist(" , , ").isEmpty());
+  }
+
+  @Test
+  void parseAllowlist_splitsTrimsAndDropsEmptySegments() {
+    assertEquals(List.of("a", "b"), LastModifiedRepositoryPolicy.parseAllowlist("a,b"));
+    assertEquals(List.of("x", "y"), LastModifiedRepositoryPolicy.parseAllowlist(" x , y "));
+    assertEquals(List.of("one"), LastModifiedRepositoryPolicy.parseAllowlist("one,,,"));
+  }
+
+  @Test
+  void repoKeyMatchesAllowlist_substringMatch() {
+    List<String> patterns = List.of("-local", "cache");
+    assertTrue(LastModifiedRepositoryPolicy.repoKeyMatchesAllowlist("npm-local", patterns));
+    assertTrue(LastModifiedRepositoryPolicy.repoKeyMatchesAllowlist("maven-cache-remote", patterns));
+    assertFalse(LastModifiedRepositoryPolicy.repoKeyMatchesAllowlist("npm-remote", patterns));
+  }
+
+  @Test
+  void repoKeyMatchesAllowlist_emptyPatterns_neverMatches() {
+    assertFalse(LastModifiedRepositoryPolicy.repoKeyMatchesAllowlist("anything", List.of()));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <version.maven.resources.plugin>3.1.0</version.maven.resources.plugin>
     <version.maven.site.plugin>3.7.1</version.maven.site.plugin>
     <version.maven.surefire.plugin>3.0.0-M3</version.maven.surefire.plugin>
-    <jackson-databind.version>2.21.1</jackson-databind.version>
+    <jackson-databind.version>2.21.2</jackson-databind.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Feature
- Add allowlist for last modified date instead of remote vs local check.
- Deprecate remote vs local check as Artifactory always returns local for target repositories.