### PR TITLE
chore: transfer ownership to @snyk/engines_sca-scanners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/open-source_composition-analysis
+* @snyk/engines_sca-scanners


### PR DESCRIPTION
### What?

- `.github/CODEOWNERS`: ownership rules assigning `@snyk/open-source_composition-analysis` move to `@snyk/engines_sca-scanners` (other co-owners on shared lines are unchanged).

### Why?

`@snyk/engines_sca-scanners` now owns this repo, so review requests should land with them rather than the previous team.

---

> [!NOTE]
> **Low Risk**
> Metadata-only ownership update; no runtime or behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only ownership update in `.github/CODEOWNERS`; no runtime or behavioral impact.
> 
> **Overview**
> Updates the default GitHub code owner for the repository from `@snyk/open-source_composition-analysis` to `@snyk/engines_sca-scanners` in `.github/CODEOWNERS`, so PR review requests and ownership routing align with the team that now maintains the repo.
> 
> No application code, CI behavior, or runtime logic changes—only repository metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311cc0433ddf697447fe8d237f87d6ab30e4a5cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->