### PR TITLE
chore: add prodsec-orb-runtime context to config.yaml [PRODSEC-10569]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
+            - prodsec-orb-runtime
           channel: snyk-vuln-alerts-sca
           filters:
             branches:
@@ -32,4 +33,6 @@ workflows:
 
       - security-scans:
           name: Security Scans
-          context: open_source-managed
+          context:
+            - open_source-managed
+            - prodsec-orb-runtime


### PR DESCRIPTION
## Summary
This PR adds the `prodsec-orb-runtime` context to jobs and workflows that use prodsec-orb commands.

## Changes
- Added `prodsec-orb-runtime` context to jobs using:
  - `prodsec/secrets-scan`
  - `prodsec/security_scans`
  - `prodsec/container_scan`
  - `publish/publish`

## Related
PRODSEC-10569

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only context wiring for existing prodsec jobs; no application or security logic changes.
> 
> **Overview**
> Adds the **`prodsec-orb-runtime`** CircleCI context to two jobs in the **CICD** workflow so prodsec orb steps can resolve runtime credentials/config.
> 
> **Scan repository for secrets** (`prodsec/secrets-scan`) keeps **`snyk-bot-slack`** and now also uses **`prodsec-orb-runtime`**. **Security Scans** (`security-scans`) keeps **`open_source-managed`** and adds **`prodsec-orb-runtime`** (replacing a single-context form with a list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10638ee5e92d34e9bc8fd17e789057820b3ae065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->