### PR TITLE
chore: retag team ownership to sca-scanners [CMPA-724]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,5 +34,5 @@ workflows:
       - security-scans:
           name: Security Scans
           context:
-            - open_source-managed
+            - engines_sca-scanners
             - prodsec-orb-runtime

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   type: external-tooling
   lifecycle: "-"
-  owner: os-managed
+  owner: sca-scanners


### PR DESCRIPTION
### What?

`catalog-info.yaml` ownership metadata moves to the merged team:

| Field | Before | After |
|---|---|---|
| `owner` | retired team name | `sca-scanners` |
| `github.com/team-slug` | `snyk/<retired>` | `snyk/engines_sca-scanners` |

The two conventions differ on purpose: only **GitHub and CircleCI** carry the `engines_` group
prefix, so Backstage `owner` is the bare slug. Matches siblings such as `sca-findings`
(`owner: os-flows`) and `error-catalog` (`owner: cloud-experience`).

### CircleCI context

Also moves the CircleCI context from the `open_source-managed` stop-gap to the new
**`engines_sca-scanners`** context (`6070a8d4-dd66-4341-ae23-49571225b6da`), created by @wayne-grant
today — see the [#ask-prodsec thread](https://snyk.enterprise.slack.com/archives/C0BHRS7BW4A/p1787912064031849).
Per that discussion the plan is to go straight to the correct team rather than leave the stop-gap in place,
since these repos are being touched anyway.

Note contexts **do** carry the `engines_` prefix, unlike the Polaris/Backstage owner values above.

**Why this is safe here:** `engines_sca-scanners` currently provides only `SNYK_TOKEN`, whereas
`open_source-managed` also holds a `CIRCLECI_TOKEN`. Every job in this repo that requests the
context is a Snyk scanning job needing `SNYK_TOKEN` only — this repo references no Circle PAT at
all, so nothing loses a variable.


### Ownership is set in more places than expected

Rather than naming individual files, the transform walks **all of `helm/`** plus
`catalog-info.yaml`, matching on *key name + retired value* (never on parent path, which varies
per repo):

| Location | Keys |
|---|---|
| `catalog-info.yaml` | `owner`, `github.com/team-slug` |
| `helm/Chart.yaml` | `team` |
| `helm/values.yaml` | `owner`, `snykowner` — under `polaris-datadog-alerting` (the monitor tag), `polaris-namespace`, `namespace`, `global`, `polarisPostgres`, `polarisRedis*`, bucket blocks |
| `helm/values/<env>.yaml` | per-environment overrides |
| `helm/templates/**` incl. `_helpers.tpl` and subcharts | `snykowner`, `snyk.io/owner` — these become **labels and annotations on the running pods** |

Unrelated `owner:` keys are left alone — matching on the retired value means e.g. a secret owner
under `npmDepsAuthnToken.consumer` is untouched.

### Pruning stale `catalog-info.yaml` entries

Removed rather than updated, since each is either superseded or points somewhere that no longer
resolves:

| Entry | Why removed |
|---|---|
| `snyk.io/jira-prefix` | Names a Jira *project*, which is not renamed when a GitHub team is. It was being updated on the wrong trigger, and it is not the annotation the Backstage Jira plugin reads (`jira/project-key`). |
| Ask-channel link | Superseded by the `## Contact` section added to the README earlier in this migration. |
| Notion links | Notion is no longer used. |
| Datadog links naming a retired team | e.g. an SLO query `team:unify AND service:…` — stops resolving once the team tag changes, so the link would silently go stale. |
| `pagerduty.com/service-id` | Unused. |

Where pruning empties the `links:` block, the key itself is removed rather than left with no
entries. Datadog links that do **not** reference a retired team are left alone.

Every one of these is checked per repo and reported, so a repo that simply does not set them is
distinguishable from one that was skipped.

### Why?

`open-source_unify`, `open-source_analysis-platform`, `os-managed` and `os-ecosystems` have
merged into `@snyk/engines_sca-scanners` (CODEOWNERS already migrated under CMPA-724).

### Risk

**None to alerting.** This repo has no Polaris or Datadog configuration, so nothing about monitor
tagging or paging changes. Safe to merge at any time.

Not touched: Slack channels/handles/mentions, the `UNIFY` Jira prefix, dashboard/SLO URLs, and
`name:` / `project-slug:` fields — some repo names legitimately contain a retired team name.

---

> [!NOTE]
> **Low Risk**
> Metadata and CI context only; no code or runtime change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and CI context only; no application code or runtime behavior changes.
> 
> **Overview**
> Reassigns **team ownership** for the artifactory Snyk security plugin repo after the `os-managed` / open-source teams merge into **`sca-scanners`**.
> 
> **Backstage** `catalog-info.yaml` sets `spec.owner` from `os-managed` to **`sca-scanners`** (bare slug, consistent with other Polaris/Backstage components).
> 
> **CircleCI** updates two integration points: the secrets-scan job posts to **`snyk-vuln-alerts-sca-scanners`** instead of `snyk-vuln-alerts-sca`, and the Security Scans job pulls secrets from the **`engines_sca-scanners`** context instead of the `open_source-managed` stop-gap (only `SNYK_TOKEN` is needed here).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14adf51acaf5ce80908538bc5b8c121daada3d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->